### PR TITLE
Use auth_info ID as OTP token and enforce email match

### DIFF
--- a/backend/docs/member-auth-flow.md
+++ b/backend/docs/member-auth-flow.md
@@ -46,35 +46,39 @@ sequenceDiagram
   "email": "user@example.com",
   "exists": false,
   "purpose": "REGISTRATION",
-  "actionCode": "001"
+  "actionCode": "001",
+  "token": "3f7d8c56-1b2a-4e8e-9c5d-123456789abc"
 }
 ```
 - **說明**：
   - `exists`: 帳號是否已存在
   - `purpose`: 系統判定的用途（REGISTRATION 或 LOGIN）
   - `actionCode`: PRD action code（REGISTRATION=001, LOGIN=002）
+  - `token`: 後續驗證 OTP 時所需的識別碼
 
 ### 2. 驗證 OTP 並完成登入/註冊
 - **API**：`POST /api/members/auth-flow`
 - **Body 範例**：
 ```json
 {
-  "email": "user@example.com",
-  "otpCode": "123456",
-  "clientId": "web", // 選填,暫時保留欄位
-  "ip": "192.168.1.1",
-  "ua": "Mozilla/5.0...",
-  "givenName": "小明",
+    "email": "user@example.com",
+    "otpCode": "123456",
+    "token": "3f7d8c56-1b2a-4e8e-9c5d-123456789abc",
+    "clientId": "web", // 選填,暫時保留欄位
+    "ip": "192.168.1.1",
+    "ua": "Mozilla/5.0...",
+    "givenName": "小明",
   "familyName": "王",
   "nickName": "明明",
-  "birthday": "2000-01-01"
+  "birthday": "2000-01-01",
+  "langType": "zh-TW"
 }
 ```
 - **說明**：
-  - 驗證 OTP 驗證碼
+  - 驗證 OTP 驗證碼，`email` 必須與預先發送 OTP 的信箱相同
   - 如果是新用戶（purpose=REGISTRATION），會自動註冊並登入
   - 如果是現有用戶（purpose=LOGIN），會直接登入
-  - 註冊時需要填寫 `givenName`、`familyName`、`nickName`、`birthday` 等資料
+  - 註冊時可填寫 `givenName`、`familyName`、`nickName`、`birthday`、`langType` 等資料（`langType` 預設 zh-TW）
   - access_token cookie保留15分鐘，refresh_token cookie保留14天
 - **回應**：
 ```json
@@ -99,6 +103,23 @@ sequenceDiagram
   - `cookies`: 要由 BFF 寫入 Cookie 的 token 資訊
     - `access_token`: JWT Token，有效期 1 小時
     - `refresh_token`: Refresh Token，有效期 30 天
+
+- **錯誤範例（欄位驗證失敗）**：
+```json
+{
+  "data": null,
+  "meta": null,
+  "error": {
+    "code": "400106",
+    "message": "會員資料欄位錯誤",
+    "timestamp": "2024-01-15T10:30:00Z",
+    "details": {
+      "givenName": "given_name 長度不可超過30",
+      "langType": "不支援的語系"
+    }
+  }
+}
+```
 
 ### 3. 驗證 Token
 - **API**：`POST /api/auth/verify-token`

--- a/backend/src/main/java/com/travelPlanWithAccounting/service/controller/OtpController.java
+++ b/backend/src/main/java/com/travelPlanWithAccounting/service/controller/OtpController.java
@@ -38,7 +38,7 @@ public class OtpController {
   @PostMapping("/verification")
   @Operation(
       summary = "驗證 OTP 驗證碼",
-      description = "Body 需包含 email、otpCode 與 purpose，purpose 必須與發送時一致。")
+      description = "Body 需包含 token、otpCode 與 purpose，purpose 必須與發送時一致。")
   public OtpVerifyResponse verifyOtp(@Valid @RequestBody OtpVerificationRequest request) {
     return otpService.verifyOtpResponse(request);
   }

--- a/backend/src/main/java/com/travelPlanWithAccounting/service/controller/OtpTestController.java
+++ b/backend/src/main/java/com/travelPlanWithAccounting/service/controller/OtpTestController.java
@@ -61,7 +61,8 @@ public class OtpTestController {
         purpose,
         purpose.actionCode(),
         otpData.getOtpCode(),
-        otpData.getExpiryTime());
+        otpData.getExpiryTime(),
+        otpData.getToken());
   }
 
   // ---- 僅供 dev 回傳 JSON 的資料結構 ----
@@ -73,5 +74,6 @@ public class OtpTestController {
     private String actionCode;
     private String otpCode; // dev/本機調試才回；勿在 prod 使用
     private LocalDateTime expireAt; // local time；DB 寫入為 UTC
+    private java.util.UUID token;
   }
 }

--- a/backend/src/main/java/com/travelPlanWithAccounting/service/dto/member/AuthFlowRequest.java
+++ b/backend/src/main/java/com/travelPlanWithAccounting/service/dto/member/AuthFlowRequest.java
@@ -16,6 +16,10 @@ public class AuthFlowRequest {
   @Schema(description = "使用者輸入的 OTP 驗證碼（由 preAuthFlow 寄出）")
   private String otpCode;
 
+  @NotBlank
+  @Schema(description = "預先發送 OTP 時取得的 token")
+  private String token;
+
   @Schema(description = "BFF 產生的 clientId（預留給 RT 管理）")
   private String clientId;
 
@@ -27,4 +31,6 @@ public class AuthFlowRequest {
   private String familyName;
   private String nickName;
   private java.time.LocalDate birthday;
+  @Schema(description = "語系類型", example = "zh-TW")
+  private String langType;
 }

--- a/backend/src/main/java/com/travelPlanWithAccounting/service/dto/member/PreAuthFlowResponse.java
+++ b/backend/src/main/java/com/travelPlanWithAccounting/service/dto/member/PreAuthFlowResponse.java
@@ -18,4 +18,7 @@ public class PreAuthFlowResponse {
 
   @Schema(description = "PRD action code（REGISTRATION=001, LOGIN=002）")
   private String actionCode; // 001|002
+
+  @Schema(description = "otp 驗證所需的 token")
+  private String token;
 }

--- a/backend/src/main/java/com/travelPlanWithAccounting/service/dto/otp/OtpSendResponse.java
+++ b/backend/src/main/java/com/travelPlanWithAccounting/service/dto/otp/OtpSendResponse.java
@@ -9,4 +9,5 @@ import lombok.NoArgsConstructor;
 @AllArgsConstructor
 public class OtpSendResponse {
   private String email;
+  private String token;
 }

--- a/backend/src/main/java/com/travelPlanWithAccounting/service/model/OtpData.java
+++ b/backend/src/main/java/com/travelPlanWithAccounting/service/model/OtpData.java
@@ -1,19 +1,22 @@
 package com.travelPlanWithAccounting.service.model;
 
 import java.time.LocalDateTime;
+import java.util.UUID;
 
 public class OtpData {
   private String otpCode;
   private String email;
   private LocalDateTime expiryTime;
+  private UUID token;
   private int attemptCount;
   private boolean verified;
   private LocalDateTime lastSentTime;
 
-  public OtpData(String otpCode, String email, LocalDateTime expiryTime) {
+  public OtpData(String otpCode, String email, LocalDateTime expiryTime, UUID token) {
     this.otpCode = otpCode;
     this.email = email;
     this.expiryTime = expiryTime;
+    this.token = token;
     this.attemptCount = 0;
     this.verified = false;
     this.lastSentTime = null;
@@ -41,6 +44,14 @@ public class OtpData {
 
   public void setExpiryTime(LocalDateTime expiryTime) {
     this.expiryTime = expiryTime;
+  }
+
+  public UUID getToken() {
+    return token;
+  }
+
+  public void setToken(UUID token) {
+    this.token = token;
   }
 
   public int getAttemptCount() {

--- a/backend/src/main/java/com/travelPlanWithAccounting/service/model/OtpVerificationRequest.java
+++ b/backend/src/main/java/com/travelPlanWithAccounting/service/model/OtpVerificationRequest.java
@@ -1,15 +1,13 @@
 package com.travelPlanWithAccounting.service.model;
 
-import jakarta.validation.constraints.Email;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
 
 /** 驗證 OTP 的請求物件 */
 public class OtpVerificationRequest {
 
-  @NotBlank(message = "電子郵件不能為空")
-  @Email(message = "請輸入有效的電子郵件格式")
-  private String email;
+  @NotBlank(message = "token 不能為空")
+  private String token;
 
   @NotBlank(message = "OTP 驗證碼不能為空")
   private String otpCode;
@@ -18,12 +16,12 @@ public class OtpVerificationRequest {
   @NotNull(message = "purpose 不能為空")
   private OtpPurpose purpose;
 
-  public String getEmail() {
-    return email;
+  public String getToken() {
+    return token;
   }
 
-  public void setEmail(String email) {
-    this.email = email;
+  public void setToken(String token) {
+    this.token = token;
   }
 
   public String getOtpCode() {

--- a/backend/src/main/java/com/travelPlanWithAccounting/service/repository/AuthInfoRepository.java
+++ b/backend/src/main/java/com/travelPlanWithAccounting/service/repository/AuthInfoRepository.java
@@ -12,6 +12,9 @@ public interface AuthInfoRepository extends JpaRepository<AuthInfo, UUID> {
   Optional<AuthInfo> findFirstByEmailAndCodeAndActionAndExpireAtAfterOrderByCreatedAtDesc(
       String email, String code, String action, OffsetDateTime now);
 
+  Optional<AuthInfo> findByIdAndCodeAndActionAndExpireAtAfter(
+      UUID id, String code, String action, OffsetDateTime now);
+
   @Modifying(clearAutomatically = true, flushAutomatically = true)
   @Query("update AuthInfo a set a.validation = true where a.id = :id")
   int markValidated(@Param("id") UUID id);


### PR DESCRIPTION
## Summary
- return auth_info ID as token when sending OTP and verify via token plus code
- require registration/login to validate token email against submitted email
- document new token parameter for pre-auth and auth-flow

## Testing
- `mvn -q -e -DskipTests package` *(fails: Non-resolvable parent POM, Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_688f40c65f488323bedfaaffe58f66bd