### PR TITLE
Refactor OTP caching to use tokens

### DIFF
--- a/backend/src/main/java/com/travelPlanWithAccounting/service/controller/OtpController.java
+++ b/backend/src/main/java/com/travelPlanWithAccounting/service/controller/OtpController.java
@@ -43,11 +43,13 @@ public class OtpController {
     return otpService.verifyOtpResponse(request);
   }
 
-  @GetMapping("/{email}/status")
-  @Operation(summary = "查詢 OTP 狀態", description = "以 Query String 指定 purpose；未傳則預設為 LOGIN。")
+  @GetMapping("/{token}/status")
+  @Operation(
+      summary = "查詢 OTP 狀態",
+      description = "以 Path Variable 提供 token，Query String 指定 purpose；未傳則預設為 LOGIN。")
   public OtpStatusResponse getOtpStatus(
-      @PathVariable String email,
+      @PathVariable String token,
       @RequestParam(name = "purpose", required = false) OtpPurpose purpose) {
-    return otpService.getOtpStatusResponse(email, purpose);
+    return otpService.getOtpStatusResponse(token, purpose);
   }
 }

--- a/backend/src/main/java/com/travelPlanWithAccounting/service/service/OtpCacheService.java
+++ b/backend/src/main/java/com/travelPlanWithAccounting/service/service/OtpCacheService.java
@@ -11,25 +11,25 @@ import org.springframework.stereotype.Service;
 @Service
 public class OtpCacheService {
 
-  /** 以 (email, purpose) 作為快取鍵，避免註冊與登入互相覆蓋 */
+  /** 以 (token, purpose) 作為快取鍵，避免註冊與登入互相覆蓋 */
   @Cacheable(
       value = CacheConstants.OTP_CACHE,
-      key = "T(String).valueOf(#email).concat(':').concat(#purpose.name())")
-  public OtpData getOtpData(String email, OtpPurpose purpose) {
+      key = "T(String).valueOf(#token).concat(':').concat(#purpose.name())")
+  public OtpData getOtpData(String token, OtpPurpose purpose) {
     return null; // 交由 Cache Manager 回填
   }
 
   @CachePut(
       value = CacheConstants.OTP_CACHE,
-      key = "T(String).valueOf(#email).concat(':').concat(#purpose.name())")
-  public OtpData updateOtpData(String email, OtpPurpose purpose, OtpData otpData) {
+      key = "T(String).valueOf(#token).concat(':').concat(#purpose.name())")
+  public OtpData updateOtpData(String token, OtpPurpose purpose, OtpData otpData) {
     return otpData;
   }
 
   @CacheEvict(
       value = CacheConstants.OTP_CACHE,
-      key = "T(String).valueOf(#email).concat(':').concat(#purpose.name())")
-  public void evictOtp(String email, OtpPurpose purpose) {
+      key = "T(String).valueOf(#token).concat(':').concat(#purpose.name())")
+  public void evictOtp(String token, OtpPurpose purpose) {
     // 僅負責快取移除
   }
 
@@ -61,8 +61,8 @@ public class OtpCacheService {
    * @deprecated 請改用帶 purpose 的版本
    */
   @Deprecated
-  @Cacheable(value = CacheConstants.OTP_CACHE, key = "#email + ':LOGIN'")
-  public OtpData getOtpData(String email) {
+  @Cacheable(value = CacheConstants.OTP_CACHE, key = "#token + ':LOGIN'")
+  public OtpData getOtpData(String token) {
     return null;
   }
 
@@ -70,8 +70,8 @@ public class OtpCacheService {
    * @deprecated 請改用帶 purpose 的版本
    */
   @Deprecated
-  @CachePut(value = CacheConstants.OTP_CACHE, key = "#email + ':LOGIN'")
-  public OtpData updateOtpData(String email, OtpData otpData) {
+  @CachePut(value = CacheConstants.OTP_CACHE, key = "#token + ':LOGIN'")
+  public OtpData updateOtpData(String token, OtpData otpData) {
     return otpData;
   }
 
@@ -79,8 +79,8 @@ public class OtpCacheService {
    * @deprecated 請改用帶 purpose 的版本
    */
   @Deprecated
-  @CacheEvict(value = CacheConstants.OTP_CACHE, key = "#email + ':LOGIN'")
-  public void evictOtp(String email) {}
+  @CacheEvict(value = CacheConstants.OTP_CACHE, key = "#token + ':LOGIN'")
+  public void evictOtp(String token) {}
 
   /**
    * @deprecated 請改用帶 purpose 的版本


### PR DESCRIPTION
## Summary
- refactor OTP cache to index by token instead of email
- adjust OTP service and controller to use token-based cache access

## Testing
- `mvn -q test` *(fails: Non-resolvable parent POM due to network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_688f4bbbb72c8323b9f6bdc39f5245ae