### PR TITLE
feat: add email change with double otp

### DIFF
--- a/backend/src/main/java/com/travelPlanWithAccounting/service/controller/MemberController.java
+++ b/backend/src/main/java/com/travelPlanWithAccounting/service/controller/MemberController.java
@@ -2,16 +2,16 @@ package com.travelPlanWithAccounting.service.controller;
 
 import com.travelPlanWithAccounting.service.dto.auth.AuthResponse;
 import com.travelPlanWithAccounting.service.dto.member.AuthFlowRequest;
-import com.travelPlanWithAccounting.service.dto.member.MemberProfileResponse;
-import com.travelPlanWithAccounting.service.dto.member.MemberProfileUpdateRequest;
-import com.travelPlanWithAccounting.service.dto.member.PreAuthFlowRequest;
-import com.travelPlanWithAccounting.service.dto.member.PreAuthFlowResponse;
-import com.travelPlanWithAccounting.service.dto.member.OtpTokenResponse;
-import com.travelPlanWithAccounting.service.dto.member.IdentityOtpVerifyRequest;
-import com.travelPlanWithAccounting.service.dto.member.IdentityOtpVerifyResponse;
 import com.travelPlanWithAccounting.service.dto.member.EmailChangeOtpRequest;
 import com.travelPlanWithAccounting.service.dto.member.EmailChangeRequest;
 import com.travelPlanWithAccounting.service.dto.member.EmailChangeResponse;
+import com.travelPlanWithAccounting.service.dto.member.IdentityOtpVerifyRequest;
+import com.travelPlanWithAccounting.service.dto.member.IdentityOtpVerifyResponse;
+import com.travelPlanWithAccounting.service.dto.member.MemberProfileResponse;
+import com.travelPlanWithAccounting.service.dto.member.MemberProfileUpdateRequest;
+import com.travelPlanWithAccounting.service.dto.member.OtpTokenResponse;
+import com.travelPlanWithAccounting.service.dto.member.PreAuthFlowRequest;
+import com.travelPlanWithAccounting.service.dto.member.PreAuthFlowResponse;
 import com.travelPlanWithAccounting.service.service.MemberService;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
@@ -55,14 +55,13 @@ public class MemberController {
   }
 
   @PostMapping("/email/identity-otp")
-  @Operation(summary = "發送舊信箱 OTP")
-  public OtpTokenResponse sendIdentityOtp(
-      @RequestHeader(HttpHeaders.AUTHORIZATION) String auth) {
+  @Operation(summary = "發送信箱 OTP")
+  public OtpTokenResponse sendIdentityOtp(@RequestHeader(HttpHeaders.AUTHORIZATION) String auth) {
     return memberService.sendIdentityOtp(auth);
   }
 
   @PostMapping("/email/identity-otp/verify")
-  @Operation(summary = "驗證舊信箱 OTP")
+  @Operation(summary = "驗證信箱 OTP")
   public IdentityOtpVerifyResponse verifyIdentityOtp(
       @RequestHeader(HttpHeaders.AUTHORIZATION) String auth,
       @RequestBody IdentityOtpVerifyRequest req) {

--- a/backend/src/main/java/com/travelPlanWithAccounting/service/controller/MemberController.java
+++ b/backend/src/main/java/com/travelPlanWithAccounting/service/controller/MemberController.java
@@ -6,6 +6,12 @@ import com.travelPlanWithAccounting.service.dto.member.MemberProfileResponse;
 import com.travelPlanWithAccounting.service.dto.member.MemberProfileUpdateRequest;
 import com.travelPlanWithAccounting.service.dto.member.PreAuthFlowRequest;
 import com.travelPlanWithAccounting.service.dto.member.PreAuthFlowResponse;
+import com.travelPlanWithAccounting.service.dto.member.OtpTokenResponse;
+import com.travelPlanWithAccounting.service.dto.member.IdentityOtpVerifyRequest;
+import com.travelPlanWithAccounting.service.dto.member.IdentityOtpVerifyResponse;
+import com.travelPlanWithAccounting.service.dto.member.EmailChangeOtpRequest;
+import com.travelPlanWithAccounting.service.dto.member.EmailChangeRequest;
+import com.travelPlanWithAccounting.service.dto.member.EmailChangeResponse;
 import com.travelPlanWithAccounting.service.service.MemberService;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
@@ -46,6 +52,37 @@ public class MemberController {
       @RequestHeader(HttpHeaders.AUTHORIZATION) String auth,
       @RequestBody MemberProfileUpdateRequest req) {
     return memberService.updateProfile(auth, req);
+  }
+
+  @PostMapping("/email/identity-otp")
+  @Operation(summary = "發送舊信箱 OTP")
+  public OtpTokenResponse sendIdentityOtp(
+      @RequestHeader(HttpHeaders.AUTHORIZATION) String auth) {
+    return memberService.sendIdentityOtp(auth);
+  }
+
+  @PostMapping("/email/identity-otp/verify")
+  @Operation(summary = "驗證舊信箱 OTP")
+  public IdentityOtpVerifyResponse verifyIdentityOtp(
+      @RequestHeader(HttpHeaders.AUTHORIZATION) String auth,
+      @RequestBody IdentityOtpVerifyRequest req) {
+    return memberService.verifyIdentityOtp(auth, req);
+  }
+
+  @PostMapping("/email/change-otp")
+  @Operation(summary = "發送新信箱 OTP")
+  public OtpTokenResponse sendEmailChangeOtp(
+      @RequestHeader(HttpHeaders.AUTHORIZATION) String auth,
+      @RequestBody EmailChangeOtpRequest req) {
+    return memberService.sendEmailChangeOtp(auth, req);
+  }
+
+  @PostMapping("/email")
+  @Operation(summary = "更新信箱")
+  public EmailChangeResponse changeEmail(
+      @RequestHeader(HttpHeaders.AUTHORIZATION) String auth,
+      @RequestBody EmailChangeRequest req) {
+    return memberService.changeEmail(auth, req);
   }
 
 }

--- a/backend/src/main/java/com/travelPlanWithAccounting/service/dto/member/EmailChangeOtpRequest.java
+++ b/backend/src/main/java/com/travelPlanWithAccounting/service/dto/member/EmailChangeOtpRequest.java
@@ -1,0 +1,19 @@
+package com.travelPlanWithAccounting.service.dto.member;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.Email;
+import jakarta.validation.constraints.NotBlank;
+import lombok.Data;
+
+@Data
+public class EmailChangeOtpRequest {
+  @Schema(description = "identity verification token")
+  @NotBlank
+  private String identityOtpToken;
+
+  @Schema(description = "new email")
+  @NotBlank
+  @Email
+  private String email;
+}
+

--- a/backend/src/main/java/com/travelPlanWithAccounting/service/dto/member/EmailChangeRequest.java
+++ b/backend/src/main/java/com/travelPlanWithAccounting/service/dto/member/EmailChangeRequest.java
@@ -1,0 +1,21 @@
+package com.travelPlanWithAccounting.service.dto.member;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotBlank;
+import lombok.Data;
+
+@Data
+public class EmailChangeRequest {
+  @Schema(description = "identity verification token")
+  @NotBlank
+  private String identityOtpToken;
+
+  @Schema(description = "new email otp token")
+  @NotBlank
+  private String otpToken;
+
+  @Schema(description = "new email otp code")
+  @NotBlank
+  private String otpCode;
+}
+

--- a/backend/src/main/java/com/travelPlanWithAccounting/service/dto/member/EmailChangeResponse.java
+++ b/backend/src/main/java/com/travelPlanWithAccounting/service/dto/member/EmailChangeResponse.java
@@ -1,0 +1,15 @@
+package com.travelPlanWithAccounting.service.dto.member;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+public class EmailChangeResponse {
+  @Schema(description = "operation success")
+  private boolean success;
+}
+

--- a/backend/src/main/java/com/travelPlanWithAccounting/service/dto/member/IdentityOtpVerifyRequest.java
+++ b/backend/src/main/java/com/travelPlanWithAccounting/service/dto/member/IdentityOtpVerifyRequest.java
@@ -1,0 +1,17 @@
+package com.travelPlanWithAccounting.service.dto.member;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotBlank;
+import lombok.Data;
+
+@Data
+public class IdentityOtpVerifyRequest {
+  @Schema(description = "otp token from identity verification")
+  @NotBlank
+  private String otpToken;
+
+  @Schema(description = "otp code")
+  @NotBlank
+  private String otpCode;
+}
+

--- a/backend/src/main/java/com/travelPlanWithAccounting/service/dto/member/IdentityOtpVerifyResponse.java
+++ b/backend/src/main/java/com/travelPlanWithAccounting/service/dto/member/IdentityOtpVerifyResponse.java
@@ -15,5 +15,8 @@ public class IdentityOtpVerifyResponse {
 
   @Schema(description = "token expiration time")
   private OffsetDateTime expireAt;
+
+  @Schema(description = "operation success")
+  private boolean success;
 }
 

--- a/backend/src/main/java/com/travelPlanWithAccounting/service/dto/member/IdentityOtpVerifyResponse.java
+++ b/backend/src/main/java/com/travelPlanWithAccounting/service/dto/member/IdentityOtpVerifyResponse.java
@@ -1,0 +1,19 @@
+package com.travelPlanWithAccounting.service.dto.member;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import java.time.OffsetDateTime;
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+public class IdentityOtpVerifyResponse {
+  @Schema(description = "verified identity token")
+  private String identityOtpToken;
+
+  @Schema(description = "token expiration time")
+  private OffsetDateTime expireAt;
+}
+

--- a/backend/src/main/java/com/travelPlanWithAccounting/service/dto/member/OtpTokenResponse.java
+++ b/backend/src/main/java/com/travelPlanWithAccounting/service/dto/member/OtpTokenResponse.java
@@ -1,0 +1,19 @@
+package com.travelPlanWithAccounting.service.dto.member;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import java.time.OffsetDateTime;
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+public class OtpTokenResponse {
+  @Schema(description = "otp token")
+  private String otpToken;
+
+  @Schema(description = "token expiration time")
+  private OffsetDateTime expireAt;
+}
+

--- a/backend/src/main/java/com/travelPlanWithAccounting/service/repository/AuthInfoRepository.java
+++ b/backend/src/main/java/com/travelPlanWithAccounting/service/repository/AuthInfoRepository.java
@@ -15,6 +15,9 @@ public interface AuthInfoRepository extends JpaRepository<AuthInfo, UUID> {
   Optional<AuthInfo> findByIdAndCodeAndActionAndExpireAtAfter(
       UUID id, String code, String action, OffsetDateTime now);
 
+  Optional<AuthInfo> findByIdAndActionAndValidationTrueAndExpireAtAfter(
+      UUID id, String action, OffsetDateTime now);
+
   @Modifying(clearAutomatically = true, flushAutomatically = true)
   @Query("update AuthInfo a set a.validation = true where a.id = :id")
   int markValidated(@Param("id") UUID id);

--- a/backend/src/main/java/com/travelPlanWithAccounting/service/service/MemberService.java
+++ b/backend/src/main/java/com/travelPlanWithAccounting/service/service/MemberService.java
@@ -2,39 +2,38 @@ package com.travelPlanWithAccounting.service.service;
 
 import com.travelPlanWithAccounting.service.dto.auth.AuthResponse;
 import com.travelPlanWithAccounting.service.dto.member.AuthFlowRequest;
-import com.travelPlanWithAccounting.service.dto.member.MemberProfileResponse;
-import com.travelPlanWithAccounting.service.dto.member.MemberProfileUpdateRequest;
-import com.travelPlanWithAccounting.service.dto.member.PreAuthFlowRequest;
-import com.travelPlanWithAccounting.service.dto.member.PreAuthFlowResponse;
-import com.travelPlanWithAccounting.service.dto.member.OtpTokenResponse;
-import com.travelPlanWithAccounting.service.dto.member.IdentityOtpVerifyRequest;
-import com.travelPlanWithAccounting.service.dto.member.IdentityOtpVerifyResponse;
 import com.travelPlanWithAccounting.service.dto.member.EmailChangeOtpRequest;
 import com.travelPlanWithAccounting.service.dto.member.EmailChangeRequest;
 import com.travelPlanWithAccounting.service.dto.member.EmailChangeResponse;
+import com.travelPlanWithAccounting.service.dto.member.IdentityOtpVerifyRequest;
+import com.travelPlanWithAccounting.service.dto.member.IdentityOtpVerifyResponse;
+import com.travelPlanWithAccounting.service.dto.member.MemberProfileResponse;
+import com.travelPlanWithAccounting.service.dto.member.MemberProfileUpdateRequest;
+import com.travelPlanWithAccounting.service.dto.member.OtpTokenResponse;
+import com.travelPlanWithAccounting.service.dto.member.PreAuthFlowRequest;
+import com.travelPlanWithAccounting.service.dto.member.PreAuthFlowResponse;
 import com.travelPlanWithAccounting.service.entity.AuthInfo;
 import com.travelPlanWithAccounting.service.entity.Member;
 import com.travelPlanWithAccounting.service.entity.Setting;
 import com.travelPlanWithAccounting.service.exception.InvalidOtpException;
 import com.travelPlanWithAccounting.service.exception.MemberException;
-import com.travelPlanWithAccounting.service.model.OtpPurpose;
 import com.travelPlanWithAccounting.service.model.OtpData;
+import com.travelPlanWithAccounting.service.model.OtpPurpose;
+import com.travelPlanWithAccounting.service.repository.AuthInfoRepository;
 import com.travelPlanWithAccounting.service.repository.MemberRepository;
 import com.travelPlanWithAccounting.service.repository.SettingRepository;
-import com.travelPlanWithAccounting.service.repository.AuthInfoRepository;
-import com.travelPlanWithAccounting.service.service.RefreshTokenService;
-import com.travelPlanWithAccounting.service.util.EmailValidatorUtil;
 import com.travelPlanWithAccounting.service.security.JwtUtil;
+import com.travelPlanWithAccounting.service.util.EmailValidatorUtil;
 import io.jsonwebtoken.ExpiredJwtException;
 import io.jsonwebtoken.JwtException;
 import java.time.OffsetDateTime;
 import java.time.ZoneOffset;
-import java.util.UUID;
 import java.util.ArrayList;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
+import java.util.UUID;
 import java.util.regex.Pattern;
 import lombok.RequiredArgsConstructor;
 import org.springframework.context.MessageSource;
@@ -161,7 +160,7 @@ public class MemberService {
     authInfo.setValidation(true);
     authInfo.setExpireAt(expireAt);
     authInfoRepository.save(authInfo);
-    return new IdentityOtpVerifyResponse(req.getOtpToken(), expireAt);
+    return new IdentityOtpVerifyResponse(req.getOtpToken(), expireAt, true);
   }
 
   /** 發送新信箱 OTP */
@@ -418,7 +417,9 @@ public class MemberService {
       if (req.getLangType().length() > 10) {
         fieldErrors.add(
             messageSource.getMessage("member.profile.langType.length", null, locale));
-      } else if (settingRepository.findByCategoryAndName("LANG_TYPE", req.getLangType()).isEmpty()) {
+      } else if (settingRepository
+          .findByCategoryAndName("LANG_TYPE", req.getLangType())
+          .isEmpty()) {
         fieldErrors.add(
             messageSource.getMessage("member.profile.langType.invalid", null, locale));
       }


### PR DESCRIPTION
## Summary
- add OTP-based identity verification and email update APIs
- verify old email, send OTP to new email, and finalize change

## Testing
- `mvn -q test` *(fails: Non-resolvable parent POM due to network unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_6890a7540460832386e9d4304cb41a58