### PR TITLE
Ensure identity verification token remains valid for email change

### DIFF
--- a/backend/src/main/java/com/travelPlanWithAccounting/service/repository/AuthInfoRepository.java
+++ b/backend/src/main/java/com/travelPlanWithAccounting/service/repository/AuthInfoRepository.java
@@ -18,6 +18,8 @@ public interface AuthInfoRepository extends JpaRepository<AuthInfo, UUID> {
   Optional<AuthInfo> findByIdAndActionAndValidationTrueAndExpireAtAfter(
       UUID id, String action, OffsetDateTime now);
 
+  Optional<AuthInfo> findByIdAndActionAndValidationTrue(UUID id, String action);
+
   @Modifying(clearAutomatically = true, flushAutomatically = true)
   @Query("update AuthInfo a set a.validation = true where a.id = :id")
   int markValidated(@Param("id") UUID id);

--- a/backend/src/main/java/com/travelPlanWithAccounting/service/service/MemberService.java
+++ b/backend/src/main/java/com/travelPlanWithAccounting/service/service/MemberService.java
@@ -158,6 +158,7 @@ public class MemberService {
       throw new MemberException.OtpTokenInvalid();
     }
     OffsetDateTime expireAt = OffsetDateTime.now(ZoneOffset.UTC).plusMinutes(10);
+    authInfo.setValidation(true);
     authInfo.setExpireAt(expireAt);
     authInfoRepository.save(authInfo);
     return new IdentityOtpVerifyResponse(req.getOtpToken(), expireAt);
@@ -186,10 +187,11 @@ public class MemberService {
     OffsetDateTime nowUtc = OffsetDateTime.now(ZoneOffset.UTC);
     AuthInfo identityAuth =
         authInfoRepository
-            .findByIdAndActionAndValidationTrueAndExpireAtAfter(
-                identityId, OtpPurpose.IDENTITY_VERIFICATION.actionCode(), nowUtc)
+            .findByIdAndActionAndValidationTrue(
+                identityId, OtpPurpose.IDENTITY_VERIFICATION.actionCode())
             .orElseThrow(MemberException.OtpTokenInvalid::new);
-    if (!identityAuth.getMemberId().equals(member.getId())) {
+    if (!identityAuth.getMemberId().equals(member.getId())
+        || identityAuth.getExpireAt().isBefore(nowUtc)) {
       throw new MemberException.OtpTokenInvalid();
     }
     OtpData otpData = otpService.generateOtp(req.getEmail(), OtpPurpose.EMAIL_CHANGE);
@@ -215,10 +217,11 @@ public class MemberService {
     OffsetDateTime nowUtc = OffsetDateTime.now(ZoneOffset.UTC);
     AuthInfo identityAuth =
         authInfoRepository
-            .findByIdAndActionAndValidationTrueAndExpireAtAfter(
-                identityId, OtpPurpose.IDENTITY_VERIFICATION.actionCode(), nowUtc)
+            .findByIdAndActionAndValidationTrue(
+                identityId, OtpPurpose.IDENTITY_VERIFICATION.actionCode())
             .orElseThrow(MemberException.OtpTokenInvalid::new);
-    if (!identityAuth.getMemberId().equals(member.getId())) {
+    if (!identityAuth.getMemberId().equals(member.getId())
+        || identityAuth.getExpireAt().isBefore(nowUtc)) {
       throw new MemberException.OtpTokenInvalid();
     }
     AuthInfo emailAuth;


### PR DESCRIPTION
## Summary
- Preserve validation flag and extend expiration when verifying identity OTP
- Manually check identity token expiration in email change flows
- Add repository helper for fetching validated identity token

## Testing
- `mvn -q test` *(fails: Non-resolvable parent POM; Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_6893221750d48323890e508ae80ea096