### PR TITLE
feat: use Accept-Language header for localization

### DIFF
--- a/backend/src/main/java/com/travelPlanWithAccounting/service/config/I18nConfig.java
+++ b/backend/src/main/java/com/travelPlanWithAccounting/service/config/I18nConfig.java
@@ -42,10 +42,10 @@ public class I18nConfig {
     // 設定支援的 Locales，若 Accept-Language 沒設定或不在這清單內就會使用預設的 Locale
     List<Locale> supportedLocales = new ArrayList<>();
     supportedLocales.add(Locale.TAIWAN);
-    supportedLocales.add(Locale.ENGLISH);
+    supportedLocales.add(Locale.US);
 
     AcceptHeaderLocaleResolver acceptHeaderLocaleResolver = new AcceptHeaderLocaleResolver();
-    acceptHeaderLocaleResolver.setDefaultLocale(Locale.ENGLISH); // 預設 Locale
+    acceptHeaderLocaleResolver.setDefaultLocale(Locale.TAIWAN); // 預設 Locale
     acceptHeaderLocaleResolver.setSupportedLocales(supportedLocales);
     return acceptHeaderLocaleResolver;
   }

--- a/backend/src/main/java/com/travelPlanWithAccounting/service/controller/MemberController.java
+++ b/backend/src/main/java/com/travelPlanWithAccounting/service/controller/MemberController.java
@@ -35,7 +35,9 @@ public class MemberController {
 
   @PostMapping("/auth-flow")
   @Operation(summary = "驗證 OTP -> 登入/註冊 -> 回 AT/RT（只回一層 data）")
-  public AuthResponse authFlow(@RequestBody AuthFlowRequest req) {
+  public AuthResponse authFlow(
+      @RequestHeader(HttpHeaders.ACCEPT_LANGUAGE) String lang,
+      @RequestBody AuthFlowRequest req) {
     return memberService.authFlow(req);
   }
 
@@ -50,6 +52,7 @@ public class MemberController {
   @Operation(summary = "修改會員資料")
   public MemberProfileResponse updateProfile(
       @RequestHeader(HttpHeaders.AUTHORIZATION) String auth,
+      @RequestHeader(HttpHeaders.ACCEPT_LANGUAGE) String lang,
       @RequestBody MemberProfileUpdateRequest req) {
     return memberService.updateProfile(auth, req);
   }

--- a/backend/src/main/java/com/travelPlanWithAccounting/service/controller/SearchController.java
+++ b/backend/src/main/java/com/travelPlanWithAccounting/service/controller/SearchController.java
@@ -55,16 +55,19 @@ public class SearchController {
 
   // ==================== 原有的搜尋 API ====================
 
-  @GetMapping("/countries/{langType}")
+  @GetMapping("/countries")
   @Operation(summary = "取得國家列表 (DTO 格式)")
-  public List<Country> searchCountries(@PathVariable String langType) {
+  public List<Country> searchCountries(
+      @RequestHeader(HttpHeaders.ACCEPT_LANGUAGE) String langType) {
     return searchService.searchCountries(langType);
   }
 
   @PostMapping("/regions")
   @Operation(summary = "取得地區和城市 (DTO 格式)")
-  public List<Region> searchRegions(@RequestBody SearchRequest request) {
-    return searchService.searchRegions(request.getCode(), request.getLangType());
+  public List<Region> searchRegions(
+      @RequestHeader(HttpHeaders.ACCEPT_LANGUAGE) String langType,
+      @RequestBody SearchRequest request) {
+    return searchService.searchRegions(request.getCode(), langType);
   }
 
   @GetMapping("/allLocations")
@@ -81,20 +84,25 @@ public class SearchController {
 
   @PostMapping("/searchNearbyByLocationCode")
   @Operation(summary = "根據 Location 代碼搜尋附近景點")
-  public List<LocationSearch> searchNearbyByLocationCode(@RequestBody SearchRequest request) {
-    return searchService.searchNearbyByLocationCode(request);
+  public List<LocationSearch> searchNearbyByLocationCode(
+      @RequestHeader(HttpHeaders.ACCEPT_LANGUAGE) String langType,
+      @RequestBody SearchRequest request) {
+    return searchService.searchNearbyByLocationCode(request, langType);
   }
 
   @PostMapping("/searchTextByLocationCode")
   @Operation(summary = "根據 Location 代碼和文字查詢搜尋景點")
-  public List<LocationSearch> searchTextByLocationCode(@RequestBody TextSearchRequest request) {
-    return searchService.searchTextByLocationCode(request);
+  public List<LocationSearch> searchTextByLocationCode(
+      @RequestHeader(HttpHeaders.ACCEPT_LANGUAGE) String langType,
+      @RequestBody TextSearchRequest request) {
+    return searchService.searchTextByLocationCode(request, langType);
   }
 
   @GetMapping("/placeDetails")
   @Operation(summary = "取得地點詳細資訊 (含照片)")
   public PlaceDetailResponse getPlaceDetails(
-      @RequestParam String placeId, @RequestParam(defaultValue = "zh-TW") String langType) {
+      @RequestHeader(HttpHeaders.ACCEPT_LANGUAGE) String langType,
+      @RequestParam String placeId) {
     return searchService.getPlaceDetailById(placeId, langType);
   }
 
@@ -102,6 +110,7 @@ public class SearchController {
   @Operation(summary = "儲存會員景點（優先取 Access-Token 的 sub）")
   public SaveMemberPoiResponse saveMemberPoi(
       @RequestHeader(value = HttpHeaders.AUTHORIZATION, required = false) String auth,
+      @RequestHeader(HttpHeaders.ACCEPT_LANGUAGE) String langType,
       @Valid @RequestBody SaveMemberPoiRequest req) {
 
     UUID authMemberId = null;
@@ -114,6 +123,6 @@ public class SearchController {
       }
     }
 
-    return searchService.saveMemberPoi(authMemberId, req);
+    return searchService.saveMemberPoi(authMemberId, req, langType);
   }
 }

--- a/backend/src/main/java/com/travelPlanWithAccounting/service/dto/member/AuthFlowRequest.java
+++ b/backend/src/main/java/com/travelPlanWithAccounting/service/dto/member/AuthFlowRequest.java
@@ -31,6 +31,4 @@ public class AuthFlowRequest {
   private String familyName;
   private String nickName;
   private java.time.LocalDate birthday;
-  @Schema(description = "語系類型", example = "zh-TW")
-  private String langType;
 }

--- a/backend/src/main/java/com/travelPlanWithAccounting/service/dto/member/MemberProfileUpdateRequest.java
+++ b/backend/src/main/java/com/travelPlanWithAccounting/service/dto/member/MemberProfileUpdateRequest.java
@@ -26,8 +26,5 @@ public class MemberProfileUpdateRequest implements Serializable {
 
   @Schema(description = "是否訂閱")
   private Boolean subscribe;
-
-  @Schema(description = "語系類型", example = "zh-TW")
-  private String langType;
 }
 

--- a/backend/src/main/java/com/travelPlanWithAccounting/service/dto/memberpoi/SaveMemberPoiRequest.java
+++ b/backend/src/main/java/com/travelPlanWithAccounting/service/dto/memberpoi/SaveMemberPoiRequest.java
@@ -6,5 +6,4 @@ import lombok.Data;
 public class SaveMemberPoiRequest {
   private String memberId;      // optional, server will validate vs auth
   private String placeId;
-  private String langType;
 }

--- a/backend/src/main/java/com/travelPlanWithAccounting/service/dto/search/request/SearchRequest.java
+++ b/backend/src/main/java/com/travelPlanWithAccounting/service/dto/search/request/SearchRequest.java
@@ -18,9 +18,6 @@ public class SearchRequest {
   @Schema(description = "國家/城市/區域 代碼", example = "TW", requiredMode = Schema.RequiredMode.REQUIRED)
   private String code;
 
-  @Schema(description = "語言語系", example = "zh-TW", requiredMode = Schema.RequiredMode.REQUIRED)
-  private String langType;
-
   @Schema(
       description = "可選。搜尋附近特定地點。",
       example =

--- a/backend/src/main/java/com/travelPlanWithAccounting/service/dto/search/request/TextSearchRequest.java
+++ b/backend/src/main/java/com/travelPlanWithAccounting/service/dto/search/request/TextSearchRequest.java
@@ -20,9 +20,6 @@ public class TextSearchRequest {
   @Schema(description = "國家/城市/區域 代碼", example = "TW", requiredMode = Schema.RequiredMode.REQUIRED)
   private String code;
 
-  @Schema(description = "語言語系", example = "zh-TW", requiredMode = Schema.RequiredMode.REQUIRED)
-  private String langType;
-
   @Schema(
       description = "可選。搜尋附近特定地點。",
       example =

--- a/backend/src/main/java/com/travelPlanWithAccounting/service/factory/GoogleRequestFactory.java
+++ b/backend/src/main/java/com/travelPlanWithAccounting/service/factory/GoogleRequestFactory.java
@@ -11,9 +11,9 @@ import org.springframework.stereotype.Component;
 public class GoogleRequestFactory {
 
   /* NearbySearch builder */
-  public NearbySearchRequest buildNearby(Location loc, SearchRequest ui) {
+  public NearbySearchRequest buildNearby(Location loc, SearchRequest ui, String langType) {
     NearbySearchRequest req = new NearbySearchRequest();
-    req.setLanguageCode(ui.getLangType());
+    req.setLanguageCode(langType);
     req.setMaxResultCount(
         ui.getMaxResultCount() != null ? ui.getMaxResultCount() : MIN_RESULT_COUNT);
     req.setRankPreference(ui.getRankPreference() != null ? ui.getRankPreference() : RANK_DISTANCE);
@@ -35,7 +35,9 @@ public class GoogleRequestFactory {
 
   /** TextSearch builder */
   public com.travelPlanWithAccounting.service.dto.google.TextSearchRequest buildText(
-      Location loc, com.travelPlanWithAccounting.service.dto.search.request.TextSearchRequest ui) {
+      Location loc,
+      com.travelPlanWithAccounting.service.dto.search.request.TextSearchRequest ui,
+      String langType) {
 
     // 1. 建立 Google 版 Request
     com.travelPlanWithAccounting.service.dto.google.TextSearchRequest req =
@@ -43,7 +45,7 @@ public class GoogleRequestFactory {
 
     // 2. 基本參數
     req.setTextQuery(ui.getTextQuery());
-    req.setLanguageCode(ui.getLangType());
+    req.setLanguageCode(langType);
     req.setMaxResultCount(
         ui.getMaxResultCount() != null ? ui.getMaxResultCount() : MIN_RESULT_COUNT);
     req.setRankPreference(ui.getRankPreference() != null ? ui.getRankPreference() : RANK_RELEVANCE);

--- a/backend/src/main/java/com/travelPlanWithAccounting/service/service/MemberService.java
+++ b/backend/src/main/java/com/travelPlanWithAccounting/service/service/MemberService.java
@@ -104,7 +104,6 @@ public class MemberService {
       profileReq.setFamilyName(req.getFamilyName());
       profileReq.setNickName(req.getNickName());
       profileReq.setBirthday(req.getBirthday());
-      profileReq.setLangType(req.getLangType());
       validateAndApplyProfile(member, profileReq);
       try {
         authInfo = otpService.verifyOtp(req.getToken(), req.getOtpCode(), purpose);
@@ -311,37 +310,24 @@ public class MemberService {
   }
 
   private void validateAndApplyProfile(Member member, MemberProfileUpdateRequest req) {
-    String reqLang = req.getLangType();
-    Locale locale = Locale.forLanguageTag(reqLang == null ? "zh-TW" : reqLang);
-    if (locale.getLanguage().isEmpty()) {
-      locale = Locale.forLanguageTag("zh-TW");
+    Locale locale = LocaleContextHolder.getLocale();
+    Map<String, String> fieldErrors = validateProfile(req, locale);
+    if (!fieldErrors.isEmpty()) {
+      throw new MemberException.ProfileFieldsInvalid(fieldErrors);
     }
-    Locale prevLocale = LocaleContextHolder.getLocale();
-    LocaleContextHolder.setLocale(locale);
-    try {
-      Map<String, String> fieldErrors = validateProfile(req, locale);
-      if (!fieldErrors.isEmpty()) {
-        throw new MemberException.ProfileFieldsInvalid(fieldErrors);
-      }
 
-      if (req.getGivenName() != null) member.setGivenName(req.getGivenName());
-      if (req.getFamilyName() != null) member.setFamilyName(req.getFamilyName());
-      if (req.getNickName() != null) member.setNickName(req.getNickName());
-      if (req.getBirthday() != null) member.setBirthday(req.getBirthday());
-      if (req.getSubscribe() != null) member.setSubscribe(req.getSubscribe());
-      if (req.getLangType() != null) {
-        String code =
-            settingRepository
-                .findByCategoryAndName("LANG_TYPE", req.getLangType())
-                .map(Setting::getCodeName)
-                .orElse(member.getLangType());
-        member.setLangType(code);
-      } else if (member.getLangType() == null) {
-        member.setLangType("001");
-      }
-    } finally {
-      LocaleContextHolder.setLocale(prevLocale);
-    }
+    if (req.getGivenName() != null) member.setGivenName(req.getGivenName());
+    if (req.getFamilyName() != null) member.setFamilyName(req.getFamilyName());
+    if (req.getNickName() != null) member.setNickName(req.getNickName());
+    if (req.getBirthday() != null) member.setBirthday(req.getBirthday());
+    if (req.getSubscribe() != null) member.setSubscribe(req.getSubscribe());
+
+    String code =
+        settingRepository
+            .findByCategoryAndName("LANG_TYPE", locale.toLanguageTag())
+            .map(Setting::getCodeName)
+            .orElse(member.getLangType() == null ? "001" : member.getLangType());
+    member.setLangType(code);
   }
 
   private UUID resolveMemberId(String authHeader) {
@@ -411,20 +397,6 @@ public class MemberService {
         fieldErrors.add(
             messageSource.getMessage("member.profile.nickName.invalid", null, locale));
       if (!fieldErrors.isEmpty()) errors.put("nickName", String.join("; ", fieldErrors));
-    }
-
-    if (req.getLangType() != null) {
-      List<String> fieldErrors = new ArrayList<>();
-      if (req.getLangType().length() > 10) {
-        fieldErrors.add(
-            messageSource.getMessage("member.profile.langType.length", null, locale));
-      } else if (settingRepository
-          .findByCategoryAndName("LANG_TYPE", req.getLangType())
-          .isEmpty()) {
-        fieldErrors.add(
-            messageSource.getMessage("member.profile.langType.invalid", null, locale));
-      }
-      if (!fieldErrors.isEmpty()) errors.put("langType", String.join("; ", fieldErrors));
     }
 
     return errors;


### PR DESCRIPTION
## Summary
- switch locale resolver to zh-TW default and support en-US
- fetch language from `Accept-Language` header across search and member APIs
- drop `langType` fields from request DTOs and adjust services

## Testing
- `mvn -q test` *(fails: Non-resolvable parent POM, network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_6895c0ae47f483239a7abd355f8ce69f