### PR TITLE
feat: support language header for auth endpoints

### DIFF
--- a/backend/docs/member-auth-flow.md
+++ b/backend/docs/member-auth-flow.md
@@ -30,6 +30,8 @@ sequenceDiagram
 
 ## API 操作步驟
 
+> 所有 `/api/auth/**` 相關請求需在 `HTTP Header` 中附帶 `Accept-Language`（如 `zh-TW`、`en-US`），未提供或不支援時將以 `zh-TW` 為預設語系。
+
 ### 1. 預驗證流程 - 判斷登入/註冊並發送 OTP
 - **API**：`POST /api/members/pre-auth-flow`
 - **Body 範例**：
@@ -123,6 +125,7 @@ sequenceDiagram
 
 ### 3. 驗證 Token
 - **API**：`POST /api/auth/verify-token`
+- **Headers**：`Accept-Language: zh-TW` 或 `en-US`
 - **Body 範例**：
 ```json
 {
@@ -153,6 +156,7 @@ sequenceDiagram
 
 ### 4. 刷新 Access Token
 - **API**：`POST /api/auth/refresh`
+- **Headers**：`Accept-Language: zh-TW` 或 `en-US`
 - **Body 範例**：
 ```json
 {
@@ -177,6 +181,7 @@ sequenceDiagram
 
 ### 5. 登出
 - **API**：`POST /api/auth/logout`
+- **Headers**：`Accept-Language: zh-TW` 或 `en-US`
 - **Body 範例**：
 ```json
 {

--- a/backend/docs/member-auth-flow.md
+++ b/backend/docs/member-auth-flow.md
@@ -72,15 +72,14 @@ sequenceDiagram
     "givenName": "小明",
   "familyName": "王",
   "nickName": "明明",
-  "birthday": "2000-01-01",
-  "langType": "zh-TW"
+  "birthday": "2000-01-01"
 }
 ```
 - **說明**：
   - 驗證 OTP 驗證碼，`email` 必須與預先發送 OTP 的信箱相同
   - 如果是新用戶（purpose=REGISTRATION），會自動註冊並登入
   - 如果是現有用戶（purpose=LOGIN），會直接登入
-  - 註冊時可填寫 `givenName`、`familyName`、`nickName`、`birthday`、`langType` 等資料（`langType` 預設 zh-TW）
+  - 註冊時可填寫 `givenName`、`familyName`、`nickName`、`birthday`
   - access_token cookie保留15分鐘，refresh_token cookie保留14天
 - **回應**：
 ```json
@@ -116,8 +115,7 @@ sequenceDiagram
     "message": "會員資料欄位錯誤",
     "timestamp": "2024-01-15T10:30:00Z",
     "details": {
-      "givenName": "given_name 長度不可超過30",
-      "langType": "不支援的語系"
+      "givenName": "given_name 長度不可超過30"
     }
   }
 }

--- a/backend/src/main/java/com/travelPlanWithAccounting/service/controller/AuthController.java
+++ b/backend/src/main/java/com/travelPlanWithAccounting/service/controller/AuthController.java
@@ -11,6 +11,7 @@ import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpHeaders;
 import org.springframework.web.bind.annotation.*;
 
 @RestController
@@ -23,21 +24,27 @@ public class AuthController {
 
   @PostMapping("/refresh")
   @Operation(summary = "用 Refresh-Token 換新 Access-Token（MEM）")
-  public AccessTokenResponse refresh(@Valid @RequestBody AuthRefreshRequest body) {
+  public AccessTokenResponse refresh(
+      @Valid @RequestBody AuthRefreshRequest body,
+      @RequestHeader(value = HttpHeaders.ACCEPT_LANGUAGE, required = false) String lang) {
     return refreshTokenService.refreshAccessToken(
-        body.getRefreshToken(), body.getIp(), body.getUa());
+        body.getRefreshToken(), body.getIp(), body.getUa(), lang);
   }
 
   @PostMapping("/logout")
   @Operation(summary = "登出：由 refreshToken 判斷平台並撤銷（MEM）")
-  public SimpleResult logout(@Valid @RequestBody AuthLogoutByRtRequest body) {
-    boolean ok = refreshTokenService.logoutByRefreshToken(body.getRefreshToken());
+  public SimpleResult logout(
+      @Valid @RequestBody AuthLogoutByRtRequest body,
+      @RequestHeader(value = HttpHeaders.ACCEPT_LANGUAGE, required = false) String lang) {
+    boolean ok = refreshTokenService.logoutByRefreshToken(body.getRefreshToken(), lang);
     return new SimpleResult(ok);
   }
 
   @PostMapping("/verify-token")
   @Operation(summary = "驗證 Token（ACCESS/REFRESH）")
-  public VerifyTokenResponse verifyToken(@Valid @RequestBody VerifyTokenRequest req) {
-    return refreshTokenService.verifyToken(req);
+  public VerifyTokenResponse verifyToken(
+      @Valid @RequestBody VerifyTokenRequest req,
+      @RequestHeader(value = HttpHeaders.ACCEPT_LANGUAGE, required = false) String lang) {
+    return refreshTokenService.verifyToken(req, lang);
   }
 }

--- a/backend/src/test/java/com/travelPlanWithAccounting/service/controller/AuthControllerTest.java
+++ b/backend/src/test/java/com/travelPlanWithAccounting/service/controller/AuthControllerTest.java
@@ -1,0 +1,43 @@
+package com.travelPlanWithAccounting.service.controller;
+
+import static org.mockito.Mockito.verify;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import com.travelPlanWithAccounting.service.dto.auth.AccessTokenResponse;
+import com.travelPlanWithAccounting.service.service.RefreshTokenService;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.servlet.MockMvc;
+import static org.mockito.Mockito.when;
+
+@WebMvcTest(AuthController.class)
+@AutoConfigureMockMvc(addFilters = false)
+class AuthControllerTest {
+
+  @Autowired private MockMvc mockMvc;
+
+  @MockBean private RefreshTokenService refreshTokenService;
+
+  @Test
+  void refreshPassesAcceptLanguageHeader() throws Exception {
+    when(refreshTokenService.refreshAccessToken("rt", "ip", "ua", "en-US"))
+        .thenReturn(new AccessTokenResponse("at", 100L));
+
+    mockMvc
+        .perform(
+            post("/api/auth/refresh")
+                .header(HttpHeaders.ACCEPT_LANGUAGE, "en-US")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content("{\"refreshToken\":\"rt\",\"ip\":\"ip\",\"ua\":\"ua\"}"))
+        .andExpect(status().isOk());
+
+    verify(refreshTokenService).refreshAccessToken("rt", "ip", "ua", "en-US");
+  }
+}
+

--- a/backend/src/test/java/com/travelPlanWithAccounting/service/service/RefreshTokenServiceTest.java
+++ b/backend/src/test/java/com/travelPlanWithAccounting/service/service/RefreshTokenServiceTest.java
@@ -1,0 +1,37 @@
+package com.travelPlanWithAccounting.service.service;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import java.util.Locale;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+import org.springframework.context.i18n.LocaleContextHolder;
+
+import com.travelPlanWithAccounting.service.repository.RefreshTokenRepository;
+import com.travelPlanWithAccounting.service.security.JwtUtil;
+
+class RefreshTokenServiceTest {
+
+  RefreshTokenService service =
+      new RefreshTokenService(
+          Mockito.mock(RefreshTokenRepository.class), Mockito.mock(JwtUtil.class));
+
+  @Test
+  void setsLocaleFromHeader() {
+    service.verifyToken(null, "en-US");
+    assertEquals(Locale.US, LocaleContextHolder.getLocale());
+  }
+
+  @Test
+  void fallsBackToDefaultWhenUnsupported() {
+    service.verifyToken(null, "fr-FR");
+    assertEquals(Locale.TAIWAN, LocaleContextHolder.getLocale());
+  }
+
+  @Test
+  void fallsBackWhenHeaderMissing() {
+    service.verifyToken(null, null);
+    assertEquals(Locale.TAIWAN, LocaleContextHolder.getLocale());
+  }
+}
+


### PR DESCRIPTION
## Summary
- require `Accept-Language` header on auth APIs
- plumb locale through `RefreshTokenService` with fallback to `Locale.TAIWAN`
- document and test new language handling

## Testing
- `mvn -q test` *(fails: Non-resolvable parent POM ... network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_6895eac7fad88323b9e97118aaac40f6