### PR TITLE
refactor: persist otp state in database

### DIFF
--- a/backend/src/main/java/com/travelPlanWithAccounting/service/entity/AuthInfo.java
+++ b/backend/src/main/java/com/travelPlanWithAccounting/service/entity/AuthInfo.java
@@ -41,6 +41,18 @@ public class AuthInfo {
   @Column(nullable = false)
   private Boolean validation;
 
+  @Column(name = "attempt_count", nullable = false)
+  private Integer attemptCount;
+
+  @Column(name = "last_sent_at", nullable = false, columnDefinition = "timestamptz")
+  private OffsetDateTime lastSentAt;
+
+  @Column(name = "verified_at", columnDefinition = "timestamptz")
+  private OffsetDateTime verifiedAt;
+
+  @Version
+  private Long version;
+
   @Column(name = "expire_at", nullable = false, columnDefinition = "timestamptz")
   private OffsetDateTime expireAt;
 

--- a/backend/src/main/java/com/travelPlanWithAccounting/service/repository/AuthInfoRepository.java
+++ b/backend/src/main/java/com/travelPlanWithAccounting/service/repository/AuthInfoRepository.java
@@ -4,23 +4,15 @@ import com.travelPlanWithAccounting.service.entity.AuthInfo;
 import java.time.OffsetDateTime;
 import java.util.Optional;
 import java.util.UUID;
-import org.springframework.data.jpa.repository.*;
-import org.springframework.data.repository.query.Param;
+import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface AuthInfoRepository extends JpaRepository<AuthInfo, UUID> {
 
-  Optional<AuthInfo> findFirstByEmailAndCodeAndActionAndExpireAtAfterOrderByCreatedAtDesc(
-      String email, String code, String action, OffsetDateTime now);
-
-  Optional<AuthInfo> findByIdAndCodeAndActionAndExpireAtAfter(
-      UUID id, String code, String action, OffsetDateTime now);
+  Optional<AuthInfo> findByIdAndActionAndValidationFalseAndExpireAtAfter(
+      UUID id, String action, OffsetDateTime now);
 
   Optional<AuthInfo> findByIdAndActionAndValidationTrueAndExpireAtAfter(
       UUID id, String action, OffsetDateTime now);
 
   Optional<AuthInfo> findByIdAndActionAndValidationTrue(UUID id, String action);
-
-  @Modifying(clearAutomatically = true, flushAutomatically = true)
-  @Query("update AuthInfo a set a.validation = true where a.id = :id")
-  int markValidated(@Param("id") UUID id);
 }


### PR DESCRIPTION
## Summary
- track OTP attempt counts, last sent time, and verification timestamps in auth_info with optimistic locking
- sync OTP cache with database and rebuild cache on miss for verification and status checks
- centralize auth_info lookup methods for OTP validation

## Testing
- `mvn -q test` *(fails: Non-resolvable parent POM: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_689877047fa48323882cd9846714a962