### PR TITLE
feat: unify access token verification via AOP

### DIFF
--- a/backend/docs/member-auth-flow.md
+++ b/backend/docs/member-auth-flow.md
@@ -349,3 +349,16 @@ async function loginFlow() {
 ---
 
 > 若有任何錯誤，API 會回傳友善的錯誤訊息，請依照訊息提示操作。
+
+## Access Token 驗證與 AuthContext 使用
+
+- 需驗證 Access Token 的 API 於 Controller 方法上加上 `@AccessTokenRequired`。
+- 驗證成功後，會員 ID 會透過 `AuthContext` 以 `ThreadLocal` 暫存，可在下游服務取得。
+- 取得範例：
+
+```java
+@Autowired AuthContext authContext;
+UUID memberId = authContext.getCurrentMemberId();
+```
+
+- 驗證失敗或未帶 Token 時將回傳 `401 Unauthorized`。

--- a/backend/pom.xml
+++ b/backend/pom.xml
@@ -37,10 +37,15 @@
 			<artifactId>spring-boot-starter</artifactId>
 		</dependency>
 
-		<dependency>
-			<groupId>org.springframework.boot</groupId>
-			<artifactId>spring-boot-starter-web</artifactId>
-		</dependency>
+                <dependency>
+                        <groupId>org.springframework.boot</groupId>
+                        <artifactId>spring-boot-starter-web</artifactId>
+                </dependency>
+
+                <dependency>
+                        <groupId>org.springframework.boot</groupId>
+                        <artifactId>spring-boot-starter-aop</artifactId>
+                </dependency>
 
 		<dependency>
 			<groupId>org.springframework.boot</groupId>

--- a/backend/src/main/java/com/travelPlanWithAccounting/service/aspect/AccessTokenAspect.java
+++ b/backend/src/main/java/com/travelPlanWithAccounting/service/aspect/AccessTokenAspect.java
@@ -1,0 +1,49 @@
+package com.travelPlanWithAccounting.service.aspect;
+
+import com.travelPlanWithAccounting.service.controller.AuthContext;
+import com.travelPlanWithAccounting.service.security.JwtUtil;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import java.util.UUID;
+import lombok.RequiredArgsConstructor;
+import org.aspectj.lang.ProceedingJoinPoint;
+import org.aspectj.lang.annotation.Around;
+import org.aspectj.lang.annotation.Aspect;
+import org.springframework.http.HttpHeaders;
+import org.springframework.stereotype.Component;
+import org.springframework.web.context.request.RequestContextHolder;
+import org.springframework.web.context.request.ServletRequestAttributes;
+
+@Aspect
+@Component
+@RequiredArgsConstructor
+public class AccessTokenAspect {
+  private final JwtUtil jwtUtil;
+  private final AuthContext authContext;
+
+  @Around("@annotation(com.travelPlanWithAccounting.service.security.AccessTokenRequired)")
+  public Object verify(ProceedingJoinPoint pjp) throws Throwable {
+    ServletRequestAttributes attrs =
+        (ServletRequestAttributes) RequestContextHolder.getRequestAttributes();
+    if (attrs == null) return pjp.proceed();
+
+    HttpServletRequest req = attrs.getRequest();
+    HttpServletResponse resp = attrs.getResponse();
+    String auth = req.getHeader(HttpHeaders.AUTHORIZATION);
+    try {
+      if (auth == null || !auth.startsWith("Bearer ")) {
+        if (resp != null) resp.setStatus(HttpServletResponse.SC_UNAUTHORIZED);
+        return null;
+      }
+      var jws = jwtUtil.verify(auth.substring(7));
+      UUID id = UUID.fromString(jws.getPayload().getSubject());
+      authContext.setCurrentMemberId(id);
+      return pjp.proceed();
+    } catch (Exception e) {
+      if (resp != null) resp.setStatus(HttpServletResponse.SC_UNAUTHORIZED);
+      return null;
+    } finally {
+      authContext.clear();
+    }
+  }
+}

--- a/backend/src/main/java/com/travelPlanWithAccounting/service/controller/AuthContext.java
+++ b/backend/src/main/java/com/travelPlanWithAccounting/service/controller/AuthContext.java
@@ -4,8 +4,12 @@ import java.util.UUID;
 
 /**
  * 從安全框架 (JWT / session) 取得登入會員。
- * 實作例：AuthContextImpl 於 SecurityConfig 透過 SecurityContextHolder 解析。
+ * 由 AOP 在驗證 Access Token 後寫入 ThreadLocal。
  */
 public interface AuthContext {
   UUID getCurrentMemberId();
+
+  void setCurrentMemberId(UUID id);
+
+  void clear();
 }

--- a/backend/src/main/java/com/travelPlanWithAccounting/service/controller/MemberController.java
+++ b/backend/src/main/java/com/travelPlanWithAccounting/service/controller/MemberController.java
@@ -13,10 +13,11 @@ import com.travelPlanWithAccounting.service.dto.member.OtpTokenResponse;
 import com.travelPlanWithAccounting.service.dto.member.PreAuthFlowRequest;
 import com.travelPlanWithAccounting.service.dto.member.PreAuthFlowResponse;
 import com.travelPlanWithAccounting.service.service.MemberService;
+import com.travelPlanWithAccounting.service.security.AccessTokenRequired;
+import com.travelPlanWithAccounting.service.controller.AuthContext;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
-import org.springframework.http.HttpHeaders;
 import org.springframework.web.bind.annotation.*;
 
 @RestController
@@ -26,6 +27,7 @@ import org.springframework.web.bind.annotation.*;
 public class MemberController {
 
   private final MemberService memberService;
+  private final AuthContext authContext;
 
   @PostMapping("/pre-auth-flow")
   @Operation(summary = "判斷登入/註冊並發送 OTP")
@@ -40,48 +42,45 @@ public class MemberController {
   }
 
   @GetMapping("/profile")
+  @AccessTokenRequired
   @Operation(summary = "查詢會員資料")
-  public MemberProfileResponse getProfile(
-      @RequestHeader(HttpHeaders.AUTHORIZATION) String auth) {
-    return memberService.getProfile(auth);
+  public MemberProfileResponse getProfile() {
+    return memberService.getProfile(authContext.getCurrentMemberId());
   }
 
   @PostMapping("/profile")
+  @AccessTokenRequired
   @Operation(summary = "修改會員資料")
-  public MemberProfileResponse updateProfile(
-      @RequestHeader(HttpHeaders.AUTHORIZATION) String auth,
-      @RequestBody MemberProfileUpdateRequest req) {
-    return memberService.updateProfile(auth, req);
+  public MemberProfileResponse updateProfile(@RequestBody MemberProfileUpdateRequest req) {
+    return memberService.updateProfile(authContext.getCurrentMemberId(), req);
   }
 
   @PostMapping("/email/identity-otp")
+  @AccessTokenRequired
   @Operation(summary = "發送信箱 OTP")
-  public OtpTokenResponse sendIdentityOtp(@RequestHeader(HttpHeaders.AUTHORIZATION) String auth) {
-    return memberService.sendIdentityOtp(auth);
+  public OtpTokenResponse sendIdentityOtp() {
+    return memberService.sendIdentityOtp(authContext.getCurrentMemberId());
   }
 
   @PostMapping("/email/identity-otp/verify")
+  @AccessTokenRequired
   @Operation(summary = "驗證信箱 OTP")
-  public IdentityOtpVerifyResponse verifyIdentityOtp(
-      @RequestHeader(HttpHeaders.AUTHORIZATION) String auth,
-      @RequestBody IdentityOtpVerifyRequest req) {
-    return memberService.verifyIdentityOtp(auth, req);
+  public IdentityOtpVerifyResponse verifyIdentityOtp(@RequestBody IdentityOtpVerifyRequest req) {
+    return memberService.verifyIdentityOtp(authContext.getCurrentMemberId(), req);
   }
 
   @PostMapping("/email/change-otp")
+  @AccessTokenRequired
   @Operation(summary = "發送新信箱 OTP")
-  public OtpTokenResponse sendEmailChangeOtp(
-      @RequestHeader(HttpHeaders.AUTHORIZATION) String auth,
-      @RequestBody EmailChangeOtpRequest req) {
-    return memberService.sendEmailChangeOtp(auth, req);
+  public OtpTokenResponse sendEmailChangeOtp(@RequestBody EmailChangeOtpRequest req) {
+    return memberService.sendEmailChangeOtp(authContext.getCurrentMemberId(), req);
   }
 
   @PostMapping("/email")
+  @AccessTokenRequired
   @Operation(summary = "更新信箱")
-  public EmailChangeResponse changeEmail(
-      @RequestHeader(HttpHeaders.AUTHORIZATION) String auth,
-      @RequestBody EmailChangeRequest req) {
-    return memberService.changeEmail(auth, req);
+  public EmailChangeResponse changeEmail(@RequestBody EmailChangeRequest req) {
+    return memberService.changeEmail(authContext.getCurrentMemberId(), req);
   }
 
 }

--- a/backend/src/main/java/com/travelPlanWithAccounting/service/security/AccessTokenRequired.java
+++ b/backend/src/main/java/com/travelPlanWithAccounting/service/security/AccessTokenRequired.java
@@ -1,0 +1,10 @@
+package com.travelPlanWithAccounting.service.security;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Target(ElementType.METHOD)
+@Retention(RetentionPolicy.RUNTIME)
+public @interface AccessTokenRequired {}

--- a/backend/src/main/java/com/travelPlanWithAccounting/service/security/AuthContextImpl.java
+++ b/backend/src/main/java/com/travelPlanWithAccounting/service/security/AuthContextImpl.java
@@ -1,0 +1,25 @@
+package com.travelPlanWithAccounting.service.security;
+
+import com.travelPlanWithAccounting.service.controller.AuthContext;
+import java.util.UUID;
+import org.springframework.stereotype.Component;
+
+@Component
+public class AuthContextImpl implements AuthContext {
+  private static final ThreadLocal<UUID> HOLDER = new ThreadLocal<>();
+
+  @Override
+  public UUID getCurrentMemberId() {
+    return HOLDER.get();
+  }
+
+  @Override
+  public void setCurrentMemberId(UUID id) {
+    HOLDER.set(id);
+  }
+
+  @Override
+  public void clear() {
+    HOLDER.remove();
+  }
+}

--- a/backend/src/main/java/com/travelPlanWithAccounting/service/security/SecurityFilter.java
+++ b/backend/src/main/java/com/travelPlanWithAccounting/service/security/SecurityFilter.java
@@ -5,54 +5,21 @@ import jakarta.servlet.ServletException;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import java.io.IOException;
-import lombok.RequiredArgsConstructor;
-import org.springframework.http.HttpHeaders;
 import org.springframework.stereotype.Component;
-import org.springframework.util.AntPathMatcher;
 import org.springframework.web.filter.OncePerRequestFilter;
 
 @Component
-@RequiredArgsConstructor
 public class SecurityFilter extends OncePerRequestFilter {
-
-  private final JwtUtil jwtUtil;
-  private static final AntPathMatcher MATCHER = new AntPathMatcher();
 
   @Override
   protected boolean shouldNotFilter(HttpServletRequest request) {
-    String p = request.getServletPath();
-
-    /* 唯一需要驗證的路徑 */
-    if (MATCHER.match("/api/search/saveMemberPoi", p)) return false;
-
-    /* 其餘 API 一律放行 ↓ */
-    if (MATCHER.match("/api/members/**", p)) return true;
-    if (MATCHER.match("/api/auth/**", p)) return true;
-    if (MATCHER.match("/api/auth/otps/**", p)) return true;
-    if (MATCHER.match("/api/auth/otps-test/**", p)) return true;
-    if (MATCHER.match("/v3/api-docs/**", p)) return true;
-    if (MATCHER.match("/swagger-ui/**", p)) return true;
-    if (MATCHER.match("/actuator/health/**", p)) return true;
-
-    return true; // 其它路徑一律不過濾
+    return true;
   }
 
   @Override
   protected void doFilterInternal(
       HttpServletRequest req, HttpServletResponse resp, FilterChain chain)
       throws ServletException, IOException {
-
-    try {
-      String auth = req.getHeader(HttpHeaders.AUTHORIZATION);
-      if (auth == null || !auth.startsWith("Bearer ")) {
-        resp.setStatus(HttpServletResponse.SC_UNAUTHORIZED);
-        return;
-      }
-      jwtUtil.verify(auth.substring(7)); // 驗簽即可，通過就放行
-      chain.doFilter(req, resp);
-
-    } catch (Exception e) {
-      resp.setStatus(HttpServletResponse.SC_UNAUTHORIZED);
-    }
+    chain.doFilter(req, resp);
   }
 }

--- a/backend/src/test/java/com/travelPlanWithAccounting/service/security/AccessTokenAspectTests.java
+++ b/backend/src/test/java/com/travelPlanWithAccounting/service/security/AccessTokenAspectTests.java
@@ -1,0 +1,69 @@
+package com.travelPlanWithAccounting.service.security;
+
+import static org.mockito.Mockito.*;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import com.travelPlanWithAccounting.service.aspect.AccessTokenAspect;
+import com.travelPlanWithAccounting.service.controller.AuthContext;
+import io.jsonwebtoken.Claims;
+import io.jsonwebtoken.Jws;
+import io.jsonwebtoken.Jwts;
+import java.util.UUID;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.context.annotation.Import;
+import org.springframework.http.HttpHeaders;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@WebMvcTest(AccessTokenAspectTests.TestController.class)
+@Import({AccessTokenAspect.class, AuthContextImpl.class})
+class AccessTokenAspectTests {
+
+  @Autowired private MockMvc mockMvc;
+  @MockBean private JwtUtil jwtUtil;
+
+  @Test
+  void missingToken() throws Exception {
+    mockMvc.perform(get("/test")).andExpect(status().isUnauthorized());
+  }
+
+  @Test
+  void invalidToken() throws Exception {
+    when(jwtUtil.verify("bad")).thenThrow(new RuntimeException());
+    mockMvc
+        .perform(get("/test").header(HttpHeaders.AUTHORIZATION, "Bearer bad"))
+        .andExpect(status().isUnauthorized());
+  }
+
+  @Test
+  void validToken() throws Exception {
+    UUID id = UUID.randomUUID();
+    Claims claims = Jwts.claims().subject(id.toString()).build();
+    Jws<Claims> jws = mock(Jws.class);
+    when(jws.getPayload()).thenReturn(claims);
+    when(jwtUtil.verify("good")).thenReturn(jws);
+    mockMvc
+        .perform(get("/test").header(HttpHeaders.AUTHORIZATION, "Bearer good"))
+        .andExpect(status().isOk());
+  }
+
+  @RestController
+  static class TestController {
+    private final AuthContext authContext;
+
+    TestController(AuthContext authContext) {
+      this.authContext = authContext;
+    }
+
+    @GetMapping("/test")
+    @AccessTokenRequired
+    String test() {
+      return authContext.getCurrentMemberId().toString();
+    }
+  }
+}


### PR DESCRIPTION
## Summary
- add `@AccessTokenRequired` annotation and `AccessTokenAspect` to verify JWTs
- store member id in `AuthContext` backed by ThreadLocal
- refactor `SearchController` and `MemberController` to use annotation-based auth and disable old `SecurityFilter`
- document access token flow and add tests for aspect
- fix jjwt test setup to build claims correctly

## Testing
- `mvn -q test` *(fails: Non-resolvable parent POM org.springframework.boot:spring-boot-starter-parent:3.5.3 - Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_689b1548d7d8832381f6bf95a4c4b5cc