### PR TITLE
feat: support i18n settings

### DIFF
--- a/backend/docs/search.md
+++ b/backend/docs/search.md
@@ -209,8 +209,12 @@ sequenceDiagram
 ### 7. 根據類別查詢設定 ⭐
 
 - **API**: `GET /api/search/settings/{category}`
-- **描述**: 根據類別查詢設定，目前只支援 `LANG_TYPE`
+- **描述**: 根據類別查詢設定，支援 `POI_TYPE`、`LANG_TYPE`
 - **請求參數**:
+  - **標頭**:
+    | 標頭              | 型別   | 必填 | 說明                    |
+    |-------------------|--------|------|-------------------------|
+    | `Accept-Language` | String | 否   | 語言類型 (預設 zh-TW)   |
   - **路徑參數**:
     | 參數      | 型別   | 必填 | 說明              |
     |-----------|--------|------|-------------------|
@@ -220,16 +224,11 @@ sequenceDiagram
   ```json
   [
     {
-      "category": "LANG_TYPE",
-      "name": "繁體中文",
-      "codeName": "zh-TW",
-      "codeDesc": "繁體中文(台灣)"
-    },
-    {
-      "category": "LANG_TYPE",
-      "name": "English",
-      "codeName": "en-US",
-      "codeDesc": "English(USA)"
+      "category": "POI_TYPE",
+      "codeName": "P001",
+      "codeDesc": "FOOD_DRINK",
+      "name": "Restaurants",
+      "description": "Food & Drink"
     }
   ]
   ```
@@ -238,22 +237,21 @@ sequenceDiagram
 
 - **API**: `GET /api/search/settings/language-types`
 - **描述**: 專門用於查詢語言類型設定的快捷端點
-- **請求參數**: 無
+- **請求參數**:
+  - **標頭**:
+    | 標頭              | 型別   | 必填 | 說明                    |
+    |-------------------|--------|------|-------------------------|
+    | `Accept-Language` | String | 否   | 語言類型 (預設 zh-TW)   |
 - **回應**: List<Setting>
 - **回應範例**:
   ```json
   [
     {
       "category": "LANG_TYPE",
-      "name": "繁體中文",
       "codeName": "zh-TW",
-      "codeDesc": "繁體中文(台灣)"
-    },
-    {
-      "category": "LANG_TYPE",
-      "name": "English",
-      "codeName": "en-US",
-      "codeDesc": "English(USA)"
+      "codeDesc": "ZH_TW",
+      "name": "繁體中文（台灣）",
+      "description": "介面語言：繁體中文（台灣）"
     }
   ]
   ```
@@ -475,12 +473,14 @@ const textSearch = await fetch('/api/search/searchTextByLocationCode', {
 }).then(res => res.json());
 
 // 5. 查詢語言類型設定
-const languageTypes = await fetch('/api/search/settings/LANG_TYPE')
-  .then(res => res.json());
+const languageTypes = await fetch('/api/search/settings/LANG_TYPE', {
+  headers: { 'Accept-Language': 'en-US' }
+}).then(res => res.json());
 
 // 6. 查詢所有語言類型設定
-const allLanguageTypes = await fetch('/api/search/settings/language-types')
-  .then(res => res.json());
+const allLanguageTypes = await fetch('/api/search/settings/language-types', {
+  headers: { 'Accept-Language': 'en-US' }
+}).then(res => res.json());
 
 // 7. 取得地點詳細資訊
 const placeDetails = await fetch('/api/search/placeDetails?placeId=ChIJN1t_tDeuEmsRUsoyG83frY4', {

--- a/backend/src/main/java/com/travelPlanWithAccounting/service/config/CacheConfig.java
+++ b/backend/src/main/java/com/travelPlanWithAccounting/service/config/CacheConfig.java
@@ -20,6 +20,7 @@ public class CacheConfig {
         CacheConstants.ONE_TIME_TOKEN_CACHE,
         CacheConstants.REFRESH_TOKEN_CACHE,
         CacheConstants.USER_TOKENS_CACHE,
-        CacheConstants.OTP_VERIFIED_TOKEN_CACHE);
+        CacheConstants.OTP_VERIFIED_TOKEN_CACHE,
+        CacheConstants.SETTING_CACHE);
   }
 }

--- a/backend/src/main/java/com/travelPlanWithAccounting/service/constant/CacheConstants.java
+++ b/backend/src/main/java/com/travelPlanWithAccounting/service/constant/CacheConstants.java
@@ -7,4 +7,5 @@ public class CacheConstants {
   public static final String REFRESH_TOKEN_CACHE = "refresh-tokens";
   public static final String USER_TOKENS_CACHE = "user-tokens";
   public static final String OTP_VERIFIED_TOKEN_CACHE = "otp-verified-token";
+  public static final String SETTING_CACHE = "settings";
 }

--- a/backend/src/main/java/com/travelPlanWithAccounting/service/controller/SearchController.java
+++ b/backend/src/main/java/com/travelPlanWithAccounting/service/controller/SearchController.java
@@ -24,6 +24,7 @@ import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestHeader;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
@@ -41,14 +42,17 @@ public class SearchController {
 
   @GetMapping("/settings/{category}")
   @Operation(summary = "根據類別查詢設定")
-  public List<SettingResponse> getSettingsByCategory(@PathVariable String category) {
-    return settingService.getSettingsByCategory(category);
+  public List<SettingResponse> getSettingsByCategory(
+      @PathVariable String category,
+      @RequestHeader(value = "Accept-Language", required = false) String lang) {
+    return settingService.getSettingsByCategory(category, lang);
   }
 
   @GetMapping("/settings/language-types")
   @Operation(summary = "查詢所有語言類型設定")
-  public List<SettingResponse> getAllLanguageTypes() {
-    return settingService.getAllLanguageTypes();
+  public List<SettingResponse> getAllLanguageTypes(
+      @RequestHeader(value = "Accept-Language", required = false) String lang) {
+    return settingService.getSettingsByCategory("LANG_TYPE", lang);
   }
 
   // ==================== 原有的搜尋 API ====================

--- a/backend/src/main/java/com/travelPlanWithAccounting/service/dto/setting/SettingResponse.java
+++ b/backend/src/main/java/com/travelPlanWithAccounting/service/dto/setting/SettingResponse.java
@@ -13,15 +13,18 @@ import lombok.NoArgsConstructor;
 @Schema(description = "設定回應 DTO")
 public class SettingResponse {
 
-  @Schema(description = "設定類別", example = "LANG_TYPE")
+  @Schema(description = "設定類別", example = "POI_TYPE")
   private String category;
 
-  @Schema(description = "設定名稱", example = "繁體中文")
-  private String name;
-
-  @Schema(description = "設定代碼", example = "zh-TW")
+  @Schema(description = "設定代碼", example = "P001")
   private String codeName;
 
-  @Schema(description = "設定描述", example = "繁體中文(台灣)")
+  @Schema(description = "固定描述代碼", example = "FOOD_DRINK")
   private String codeDesc;
+
+  @Schema(description = "顯示名稱", example = "Restaurants")
+  private String name;
+
+  @Schema(description = "設定描述", example = "Food & Drink")
+  private String description;
 }

--- a/backend/src/main/java/com/travelPlanWithAccounting/service/entity/Setting.java
+++ b/backend/src/main/java/com/travelPlanWithAccounting/service/entity/Setting.java
@@ -43,4 +43,8 @@ public class Setting extends BaseEntity {
     @OneToMany(mappedBy = "setting", cascade = CascadeType.ALL, orphanRemoval = true)
     @ToString.Exclude
     private List<SettingLog> settingLogs;
+
+    @OneToMany(mappedBy = "setting", cascade = CascadeType.ALL, orphanRemoval = true)
+    @ToString.Exclude
+    private List<SettingI18n> settingI18ns;
 }

--- a/backend/src/main/java/com/travelPlanWithAccounting/service/entity/SettingI18n.java
+++ b/backend/src/main/java/com/travelPlanWithAccounting/service/entity/SettingI18n.java
@@ -1,0 +1,45 @@
+package com.travelPlanWithAccounting.service.entity;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.Table;
+import jakarta.persistence.UniqueConstraint;
+import jakarta.validation.Valid;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.EqualsAndHashCode;
+import lombok.NoArgsConstructor;
+import lombok.ToString;
+
+@Entity
+@Valid
+@Data
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+@EqualsAndHashCode(callSuper = true)
+@Table(
+    name = "setting_i18n",
+    uniqueConstraints =
+        @UniqueConstraint(name = "uq_setting_i18n", columnNames = {"setting_id", "lang_type"}))
+public class SettingI18n extends BaseEntity {
+
+  @ManyToOne(fetch = FetchType.LAZY)
+  @JoinColumn(name = "setting_id")
+  @ToString.Exclude
+  private Setting setting;
+
+  @Column(name = "lang_type", length = 5)
+  private String langType;
+
+  @Column(name = "name", length = 255)
+  private String name;
+
+  @Column(name = "code_desc", columnDefinition = "TEXT")
+  private String codeDesc;
+}
+

--- a/backend/src/main/java/com/travelPlanWithAccounting/service/repository/SettingI18nRepository.java
+++ b/backend/src/main/java/com/travelPlanWithAccounting/service/repository/SettingI18nRepository.java
@@ -1,0 +1,10 @@
+package com.travelPlanWithAccounting.service.repository;
+
+import com.travelPlanWithAccounting.service.entity.SettingI18n;
+import java.util.UUID;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface SettingI18nRepository extends JpaRepository<SettingI18n, UUID> {}
+

--- a/backend/src/main/java/com/travelPlanWithAccounting/service/repository/SettingRepository.java
+++ b/backend/src/main/java/com/travelPlanWithAccounting/service/repository/SettingRepository.java
@@ -1,5 +1,6 @@
 package com.travelPlanWithAccounting.service.repository;
 
+import com.travelPlanWithAccounting.service.dto.setting.SettingResponse;
 import com.travelPlanWithAccounting.service.entity.Setting;
 import java.util.List;
 import java.util.Optional;
@@ -13,21 +14,29 @@ import org.springframework.stereotype.Repository;
 public interface SettingRepository extends JpaRepository<Setting, UUID> {
 
   /**
-   * 根據類別查詢設定
+   * 根據類別與語系查詢設定
    *
    * @param category 設定類別
-   * @return List<Setting>
+   * @param langType 語系內碼
+   * @param defaultLang 預設語系內碼
+   * @return List<SettingResponse>
    */
+  @Query(
+      "SELECT new com.travelPlanWithAccounting.service.dto.setting.SettingResponse(" +
+      "s.category, s.codeName, s.codeDesc, " +
+      "COALESCE(siLang.name, siDefault.name), " +
+      "COALESCE(siLang.codeDesc, siDefault.codeDesc)) " +
+      "FROM Setting s " +
+      "LEFT JOIN SettingI18n siLang ON siLang.setting = s AND siLang.langType = :langType " +
+      "LEFT JOIN SettingI18n siDefault ON siDefault.setting = s AND siDefault.langType = :defaultLang " +
+      "WHERE s.category = :category ORDER BY s.createdAt")
+  List<SettingResponse> findByCategoryWithLang(
+      @Param("category") String category,
+      @Param("langType") String langType,
+      @Param("defaultLang") String defaultLang);
+
   @Query("SELECT s FROM Setting s WHERE s.category = :category ORDER BY s.createdAt")
   List<Setting> findByCategory(@Param("category") String category);
-
-  /**
-   * 查詢所有語言類型設定
-   *
-   * @return List<Setting>
-   */
-  @Query("SELECT s FROM Setting s WHERE s.category = 'LANG_TYPE' ORDER BY s.createdAt")
-  List<Setting> findAllLanguageTypes();
 
   Optional<Setting> findByCategoryAndName(String category, String name);
 

--- a/backend/src/main/java/com/travelPlanWithAccounting/service/service/SettingService.java
+++ b/backend/src/main/java/com/travelPlanWithAccounting/service/service/SettingService.java
@@ -1,12 +1,13 @@
 package com.travelPlanWithAccounting.service.service;
 
+import com.travelPlanWithAccounting.service.constant.CacheConstants;
 import com.travelPlanWithAccounting.service.dto.setting.SettingResponse;
-import com.travelPlanWithAccounting.service.entity.Setting;
 import com.travelPlanWithAccounting.service.repository.SettingRepository;
+import com.travelPlanWithAccounting.service.util.LangTypeMapper;
 import com.travelPlanWithAccounting.service.validator.Validator;
 import java.util.List;
-import java.util.stream.Collectors;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.cache.annotation.Cacheable;
 import org.springframework.stereotype.Service;
 
 @Service
@@ -14,44 +15,26 @@ public class SettingService {
 
   @Autowired private SettingRepository settingRepository;
   @Autowired private Validator coommonValidator;
+  @Autowired private LangTypeMapper langTypeMapper;
 
   /**
-   * 根據類別查詢設定
+   * 根據類別查詢設定，並依據語系回傳對應資料。
    *
    * @param category 設定類別
+   * @param lang Accept-Language 標頭
    * @return List<SettingResponse>
    */
-  public List<SettingResponse> getSettingsByCategory(String category) {
-    // 1) 暫時限制只能查詢 LANG_TYPE
+  @Cacheable(
+      value = CacheConstants.SETTING_CACHE,
+      key = "#category + '::' + (#lang == null || #lang.isEmpty() ? 'zh-TW' : #lang)")
+  public List<SettingResponse> getSettingsByCategory(String category, String lang) {
     coommonValidator.validateCategory(category);
 
-    // 2) 查回實際結果
-    List<Setting> settings = settingRepository.findByCategory(category);
-    return settings.stream().map(this::convertToResponse).collect(Collectors.toList());
-  }
+    String language = (lang == null || lang.isEmpty()) ? "zh-TW" : lang;
+    coommonValidator.validate(language);
+    String langCode = langTypeMapper.toCode(language);
 
-  /**
-   * 查詢所有語言類型設定
-   *
-   * @return List<SettingResponse>
-   */
-  public List<SettingResponse> getAllLanguageTypes() {
-    List<Setting> settings = settingRepository.findAllLanguageTypes();
-    return settings.stream().map(this::convertToResponse).collect(Collectors.toList());
-  }
-
-  /**
-   * 將 Setting 實體轉換為 SettingResponse DTO
-   *
-   * @param setting Setting 實體
-   * @return SettingResponse
-   */
-  private SettingResponse convertToResponse(Setting setting) {
-    SettingResponse response = new SettingResponse();
-    response.setCategory(setting.getCategory());
-    response.setName(setting.getName());
-    response.setCodeName(setting.getCodeName());
-    response.setCodeDesc(setting.getCodeDesc());
-    return response;
+    return settingRepository.findByCategoryWithLang(category, langCode, "001");
   }
 }
+


### PR DESCRIPTION
## Summary
- add `SettingI18n` entity and repository
- localize setting queries via Accept-Language with cache
- document new multilingual settings API

## Testing
- `mvn -q test` *(fails: could not resolve spring-boot-starter-parent; network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68a0150f425c8323a9b50993b4545c07