### PR TITLE
refactor: use LocaleAspect for settings endpoints

### DIFF
--- a/backend/src/main/java/com/travelPlanWithAccounting/service/controller/SearchController.java
+++ b/backend/src/main/java/com/travelPlanWithAccounting/service/controller/SearchController.java
@@ -24,7 +24,6 @@ import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RequestHeader;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
@@ -42,17 +41,14 @@ public class SearchController {
 
   @GetMapping("/settings/{category}")
   @Operation(summary = "根據類別查詢設定")
-  public List<SettingResponse> getSettingsByCategory(
-      @PathVariable String category,
-      @RequestHeader(value = "Accept-Language", required = false) String lang) {
-    return settingService.getSettingsByCategory(category, lang);
+  public List<SettingResponse> getSettingsByCategory(@PathVariable String category) {
+    return settingService.getSettingsByCategory(category);
   }
 
   @GetMapping("/settings/language-types")
   @Operation(summary = "查詢所有語言類型設定")
-  public List<SettingResponse> getAllLanguageTypes(
-      @RequestHeader(value = "Accept-Language", required = false) String lang) {
-    return settingService.getSettingsByCategory("LANG_TYPE", lang);
+  public List<SettingResponse> getAllLanguageTypes() {
+    return settingService.getSettingsByCategory("LANG_TYPE");
   }
 
   // ==================== 原有的搜尋 API ====================

--- a/backend/src/main/java/com/travelPlanWithAccounting/service/service/SettingService.java
+++ b/backend/src/main/java/com/travelPlanWithAccounting/service/service/SettingService.java
@@ -8,6 +8,7 @@ import com.travelPlanWithAccounting.service.validator.Validator;
 import java.util.List;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.cache.annotation.Cacheable;
+import org.springframework.context.i18n.LocaleContextHolder;
 import org.springframework.stereotype.Service;
 
 @Service
@@ -18,19 +19,18 @@ public class SettingService {
   @Autowired private LangTypeMapper langTypeMapper;
 
   /**
-   * 根據類別查詢設定，並依據語系回傳對應資料。
+   * 根據類別查詢設定，並依據當前語系回傳對應資料。
    *
    * @param category 設定類別
-   * @param lang Accept-Language 標頭
    * @return List<SettingResponse>
    */
   @Cacheable(
       value = CacheConstants.SETTING_CACHE,
-      key = "#category + '::' + (#lang == null || #lang.isEmpty() ? 'zh-TW' : #lang)")
-  public List<SettingResponse> getSettingsByCategory(String category, String lang) {
+      key = "#category + '::' + T(org.springframework.context.i18n.LocaleContextHolder).getLocale().toLanguageTag()")
+  public List<SettingResponse> getSettingsByCategory(String category) {
     coommonValidator.validateCategory(category);
 
-    String language = (lang == null || lang.isEmpty()) ? "zh-TW" : lang;
+    String language = LocaleContextHolder.getLocale().toLanguageTag();
     coommonValidator.validate(language);
     String langCode = langTypeMapper.toCode(language);
 


### PR DESCRIPTION
## Summary
- remove explicit Accept-Language handling in SearchController settings APIs
- resolve locale in SettingService via LocaleContextHolder and cache by locale tag

## Testing
- `mvn -q test` *(fails: Non-resolvable parent POM; network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68a01b0927f483238f3dde25127d968b