### PR TITLE
feat: 會員編輯頁面元件

### DIFF
--- a/frontend/src/app/[lng]/login-process/otp.tsx
+++ b/frontend/src/app/[lng]/login-process/otp.tsx
@@ -20,8 +20,12 @@ export type OTPImperativeHandle = {
 };
 
 export default function OTPDialog({
+  title,
+  buttonText,
   ref,
 }: {
+  title?: string;
+  buttonText?: string;
   ref?: React.RefObject<OTPImperativeHandle | null>;
 }) {
   const { t } = useT("common");
@@ -99,7 +103,7 @@ export default function OTPDialog({
           onSubmit={open ? handleSubmit : (e) => e.preventDefault()}
         >
           <Grid columns="1" gap="5">
-            <DialogHeader title={t("login.otp")}></DialogHeader>
+            <DialogHeader title={title || t("login.otp")}></DialogHeader>
             <DialogBody>
               <OneTimePasswordField.Root name="otp" id="otp">
                 <Grid columns="6" gap="2" width="250px" className="mx-auto">
@@ -133,7 +137,10 @@ export default function OTPDialog({
               )}
             </DialogBody>
             <DialogFooter justify="center" withCloseBtn>
-              <Button type="submit" text={t("login.button-login")}></Button>
+              <Button
+                type="submit"
+                text={buttonText || t("login.button-login")}
+              ></Button>
             </DialogFooter>
           </Grid>
         </form>

--- a/frontend/src/app/[lng]/login-process/sign-up.tsx
+++ b/frontend/src/app/[lng]/login-process/sign-up.tsx
@@ -39,7 +39,7 @@ export default function SignUpDialog({
 }: {
   ref?: React.RefObject<SignUpImperativeHandle | null>;
 }) {
-  const { lng } = useParams();
+  const { lng } = useParams<{ lng: string }>();
   const { t } = useT("common");
   const { open, error, openDialogWithPromise, handleSubmit, handleOpenChange } =
     useDialogWithForm({
@@ -96,7 +96,7 @@ export default function SignUpDialog({
                   label={t("account.birthday")}
                   name="birthday"
                   id="birthday"
-                  localeType={lng === "zh" ? "zh-TW" : "en-US"}
+                  lng={lng}
                   calendarOptions={{
                     captionLayout: "dropdown",
                   }}

--- a/frontend/src/app/[lng]/member/LinkButton.tsx
+++ b/frontend/src/app/[lng]/member/LinkButton.tsx
@@ -1,0 +1,31 @@
+import Link from "next/link";
+import { Box, Button } from "@radix-ui/themes";
+import { Text } from "@radix-ui/themes";
+
+export default function LinkButton({
+  href,
+  icon,
+  children,
+}: {
+  href: string;
+  icon: React.ReactNode;
+  children: React.ReactNode;
+}) {
+  return (
+    <Link href={href}>
+      <Button
+        size="4"
+        variant="surface"
+        color="gray"
+        className="cursor-pointer w-full"
+        highContrast
+      >
+        {icon}
+        <Text size="3" className="shrink-0">
+          {children}
+        </Text>
+        <Box width="100%" />
+      </Button>
+    </Link>
+  );
+}

--- a/frontend/src/app/[lng]/member/edit/EditForm.tsx
+++ b/frontend/src/app/[lng]/member/edit/EditForm.tsx
@@ -1,0 +1,55 @@
+"use client";
+
+import { Container, Grid, Flex, Button, Text } from "@radix-ui/themes";
+import { useParams } from "next/navigation";
+import { useT } from "@/app/i18n/client";
+import TextField from "@/app/components/TextField";
+import DatePicker from "@/app/components/DatePicker";
+import ValidateEmail from "./ValidateEmail";
+import { InfoCircledIcon } from "@radix-ui/react-icons";
+
+export default function EditForm() {
+  const { lng } = useParams<{ lng: string }>();
+  const { t: commonTranslate } = useT("common");
+  const { t: memberTranslate } = useT("member");
+
+  return (
+    <Container size="3" px="4" py="2">
+      <Grid columns="1" gap="2">
+        <TextField label={commonTranslate("account.surname")} size="2" />
+        <TextField label={commonTranslate("account.given-name")} size="2" />
+        <TextField label={commonTranslate("account.nickname")} size="2" />
+        <DatePicker
+          label={commonTranslate("account.birthday")}
+          lng={lng}
+          size="2"
+        />
+        <Flex>
+          <TextField
+            label={commonTranslate("account.email")}
+            size="2"
+            disabled
+          />
+          <ValidateEmail />
+        </Flex>
+        <Flex>
+          <InfoCircledIcon />
+          <Text ml="1" size="1">
+            {memberTranslate("edit.email-edit-hint")}
+          </Text>
+        </Flex>
+        <Flex>
+          <Button
+            size="2"
+            my="2"
+            variant="solid"
+            className="cursor-pointer"
+            onClick={() => console.log("Save button clicked")}
+          >
+            {memberTranslate("edit.button-save")}
+          </Button>
+        </Flex>
+      </Grid>
+    </Container>
+  );
+}

--- a/frontend/src/app/[lng]/member/edit/ValidateEmail.tsx
+++ b/frontend/src/app/[lng]/member/edit/ValidateEmail.tsx
@@ -1,0 +1,123 @@
+"use client";
+
+import { useImperativeHandle, useRef } from "react";
+import { Button as ThemeButton, Grid } from "@radix-ui/themes";
+import {
+  DialogRoot,
+  DialogContent,
+  DialogHeader,
+  DialogBody,
+  DialogFooter,
+} from "@/app/components/Dialog";
+import Button from "@/app/components/Button";
+import TextField from "@/app/components/TextField";
+import OTPDialog, { OTPImperativeHandle } from "@/app/[lng]/login-process/otp";
+import useDialogWithForm, {
+  CLOSE_REJECT,
+} from "@/app/[lng]/login-process/useDialogWithForm";
+import { useT } from "@/app/i18n/client";
+
+export default function ValidateEmail() {
+  const { t: memberTranslate } = useT("member");
+  const otpDialogRef = useRef<OTPImperativeHandle>(null);
+  const newEmailOtpDialogRef = useRef<OTPImperativeHandle>(null);
+  const newEmailDialogRef = useRef<OTPImperativeHandle>(null);
+
+  const handleEditEmail = async () => {
+    try {
+      await otpDialogRef.current?.openDialogWithPromise();
+      await newEmailDialogRef.current?.openDialogWithPromise();
+      await newEmailOtpDialogRef.current?.openDialogWithPromise();
+    } catch (error) {
+      if (error === CLOSE_REJECT) {
+        return;
+      }
+      if (!error || !(error instanceof Error)) {
+        console.error("Unexpected error:", error);
+        return;
+      }
+    }
+  };
+
+  return (
+    <>
+      <ThemeButton
+        size="2"
+        my="1"
+        ml="2"
+        variant="surface"
+        className="self-end cursor-pointer"
+        onClick={handleEditEmail}
+      >
+        {memberTranslate("edit.email-edit")}
+      </ThemeButton>
+      <OTPDialog
+        ref={otpDialogRef}
+        title={memberTranslate("edit.original-email-otp")}
+        buttonText={memberTranslate("edit.button-validate")}
+      />
+      <OTPDialog
+        ref={newEmailOtpDialogRef}
+        title={memberTranslate("edit.new-email-otp")}
+        buttonText={memberTranslate("edit.button-validate")}
+      />
+      <NewEmailDialog ref={newEmailDialogRef} />
+    </>
+  );
+}
+
+function NewEmailDialog({
+  ref,
+}: {
+  ref?: React.RefObject<OTPImperativeHandle | null>;
+}) {
+  const { t } = useT("member");
+  const inputRef = useRef<HTMLInputElement | null>(null);
+  const formRef = useRef<HTMLFormElement | null>(null);
+
+  const { open, openDialogWithPromise, handleSubmit, handleOpenChange } =
+    useDialogWithForm({
+      onSubmit: async (e: React.FormEvent) => {
+        console.log("onSubmit called");
+        e.preventDefault();
+        const formData = new FormData(e.currentTarget as HTMLFormElement);
+        const email = formData.get("email") as string;
+
+        console.log("Email submitted:", email);
+        return true;
+      },
+    });
+
+  useImperativeHandle(ref, () => ({
+    openDialogWithPromise,
+  }));
+  return (
+    <DialogRoot open={open} onOpenChange={handleOpenChange}>
+      <DialogContent maxWidth="450px" size="4">
+        <form
+          ref={formRef}
+          onSubmit={open ? handleSubmit : (e) => e.preventDefault()}
+        >
+          <Grid columns="1" gap="5">
+            <DialogHeader title={t("edit.enter-email")}></DialogHeader>
+            <DialogBody>
+              <TextField
+                ref={inputRef}
+                name="email"
+                id="email"
+                size="2"
+                type="email"
+                pattern="[^@\s]+@[^@\s]+\.[^@\s]+"
+                required
+                autoFocus
+              />
+            </DialogBody>
+            <DialogFooter justify="center" withCloseBtn>
+              <Button type="submit" text={t("edit.email-edit")}></Button>
+            </DialogFooter>
+          </Grid>
+        </form>
+      </DialogContent>
+    </DialogRoot>
+  );
+}

--- a/frontend/src/app/[lng]/member/edit/page.tsx
+++ b/frontend/src/app/[lng]/member/edit/page.tsx
@@ -1,0 +1,25 @@
+import { Container, Heading } from "@radix-ui/themes";
+import { getT } from "@/app/i18n";
+import EditForm from "./EditForm";
+
+type LayoutParams = { params: { lng: string } | Promise<{ lng: string }> };
+
+export async function generateMetadata({ params }: LayoutParams) {
+  const { lng } = await params;
+  const { t } = await getT(lng, "member");
+  return { title: t("edit.title") };
+}
+
+export default async function Page({ params }: LayoutParams) {
+  const { lng } = await params;
+  const { t: memberTranslate } = await getT(lng, "member");
+
+  return (
+    <main>
+      <Container size="3" p="4">
+        <Heading as="h1">{memberTranslate("edit.title")}</Heading>
+      </Container>
+      <EditForm />
+    </main>
+  );
+}

--- a/frontend/src/app/[lng]/member/page.tsx
+++ b/frontend/src/app/[lng]/member/page.tsx
@@ -1,0 +1,41 @@
+import { Container, Heading, Grid } from "@radix-ui/themes";
+import { PersonIcon, ExitIcon } from "@radix-ui/react-icons";
+import { getT } from "@/app/i18n";
+import LinkButton from "./LinkButton";
+
+type LayoutParams = { params: { lng: string } | Promise<{ lng: string }> };
+
+export async function generateMetadata({ params }: LayoutParams) {
+  const { lng } = await params;
+  const { t } = await getT(lng, "member");
+  return { title: t("page.title") };
+}
+
+export default async function Page({ params }: LayoutParams) {
+  const { lng } = await params;
+  const { t: memberTranslate } = await getT(lng, "member");
+  const { t: commonTranslate } = await getT(lng, "common");
+  return (
+    <main>
+      <Container size="3" p="4">
+        <Heading as="h1">{memberTranslate("page.title")}</Heading>
+      </Container>
+      <Container size="3" px="4" py="2">
+        <Grid columns="1" gap="2">
+          <LinkButton
+            href="/member/edit"
+            icon={<PersonIcon width={20} height={20} />}
+          >
+            {memberTranslate("edit.title")}
+          </LinkButton>
+          <LinkButton
+            href="/member/logout"
+            icon={<ExitIcon width={20} height={20} />}
+          >
+            {commonTranslate("logout")}
+          </LinkButton>
+        </Grid>
+      </Container>
+    </main>
+  );
+}

--- a/frontend/src/app/components/DatePicker/date-picker.types.ts
+++ b/frontend/src/app/components/DatePicker/date-picker.types.ts
@@ -31,7 +31,7 @@ interface IDatePickerBaseProps {
   /**
    * 多語系支援
    */
-  localeType?: SupportLocaleType;
+  lng?: string;
   /**
    * 覆寫日曆元件屬性
    * @todo 這裡 exclude mode 因為目前沒有支援多型

--- a/frontend/src/app/components/DatePicker/index.tsx
+++ b/frontend/src/app/components/DatePicker/index.tsx
@@ -6,10 +6,15 @@ import Calendar from "./calendar";
 import TextField, { TextFieldSlot } from "@/app/components/TextField";
 import { FORMAT_TOKEN_MAP } from "./consts";
 
-import type { IDatePickerProps } from "./date-picker.types";
+import type { IDatePickerProps, SupportLocaleType } from "./date-picker.types";
+
+const langToLocaleMap: Record<string, SupportLocaleType> = {
+  en: "en-US",
+  zh: "zh-TW",
+};
 
 function DatePicker({
-  localeType = "en-US",
+  lng = "en",
   label,
   id,
   name,
@@ -18,6 +23,7 @@ function DatePicker({
   calendarOptions = {},
   required = false,
 }: IDatePickerProps) {
+  const localeType: SupportLocaleType = langToLocaleMap[lng] || "en-US";
   const inputId = useId();
 
   // Hold the month in state to control the calendar when the input changes

--- a/frontend/src/app/i18n/locales/en/common.json
+++ b/frontend/src/app/i18n/locales/en/common.json
@@ -29,6 +29,7 @@
     "otp-resend": "Resend OTP",
     "valid-time": "Valid for: {{time}} seconds."
   },
+  "logout": "Logout",
   "account": {
     "surname": "Surname",
     "given-name": "Given Name",

--- a/frontend/src/app/i18n/locales/en/member.json
+++ b/frontend/src/app/i18n/locales/en/member.json
@@ -1,0 +1,15 @@
+{
+  "page": {
+    "title": "Personal Account Settings"
+  },
+  "edit": {
+    "title": "Edit Personal Account",
+    "button-save": "Save Changes",
+    "button-validate": "Validate",
+    "email-edit": "Edit Email",
+    "email-edit-hint": "You need to verify your email when making changes.",
+    "original-email-otp": "Original Email OTP",
+    "enter-email": "Enter New Email",
+    "new-email-otp": "New Email OTP"
+  }
+}

--- a/frontend/src/app/i18n/locales/zh/common.json
+++ b/frontend/src/app/i18n/locales/zh/common.json
@@ -29,6 +29,7 @@
     "otp-resend": "重新取得驗證碼",
     "valid-time": "有效時間: {{time}} 秒"
   },
+  "logout": "登出",
   "account": {
     "surname": "姓氏",
     "given-name": "名字",

--- a/frontend/src/app/i18n/locales/zh/member.json
+++ b/frontend/src/app/i18n/locales/zh/member.json
@@ -1,0 +1,15 @@
+{
+  "page": {
+    "title": "個人帳戶設定"
+  },
+  "edit": {
+    "title": "修改基本資料",
+    "button-save": "儲存修改",
+    "button-validate": "驗證",
+    "email-edit": "修改信箱",
+    "email-edit-hint": "確定修改後需驗證",
+    "original-email-otp": "原信箱驗證碼",
+    "enter-email": "輸入新的電子信箱",
+    "new-email-otp": "新信箱驗證碼"
+  }
+}

--- a/frontend/src/app/page.tsx
+++ b/frontend/src/app/page.tsx
@@ -119,7 +119,7 @@ export default function Home() {
           </TextField>
         </div>
         <div className="space-x-4">
-          <DatePicker localeType="zh-TW" />
+          <DatePicker lng="zh" />
           <form onSubmit={(e) => e.preventDefault()}>
             <TextField
               size="2"


### PR DESCRIPTION
<img width="1025" height="285" alt="截圖 2025-08-17 14 18 55" src="https://github.com/user-attachments/assets/1f7e106c-0528-40fe-a2cc-efd8a80aba55" />
<img width="962" height="589" alt="截圖 2025-08-17 14 19 15" src="https://github.com/user-attachments/assets/e6a89e78-c0d8-480d-bb7a-0f7cb0ba691f" />

- 會員編輯頁 + 修改 email opt dialog 互動
- 開了一個會員頁面專用的翻譯字串檔 member.json 不確定這樣做好不好