### PR TITLE
Expose poiId in place details and simplify member POI save request

### DIFF
--- a/backend/docs/search.md
+++ b/backend/docs/search.md
@@ -270,11 +270,12 @@ sequenceDiagram
     | 參數      | 型別   | 必填 | 說明                        |
     |-----------|--------|------|-----------------------------|
     | `placeId` | String | 是   | Google Place 的唯一識別碼   |
-- **回應**: 地點詳細資訊
+  - **回應**: 地點詳細資訊，含資料庫 `poiId`
 - **回應範例**:
   ```json
   {
-    "id": "ChIJN1t_tDeuEmsRUsoyG83frY4",
+    "poiId": "550e8400-e29b-41d4-a716-446655440001",
+    "placeId": "ChIJN1t_tDeuEmsRUsoyG83frY4",
     "name": "Google Sydney",
     "addr": "48 Pirrama Rd, Pyrmont NSW 2009, Australia",
     "rate": 4.5,
@@ -312,17 +313,13 @@ sequenceDiagram
   - **請求體**:
     | 參數      | 型別   | 必填 | 說明                        |
     |-----------|--------|------|-----------------------------|
-    | `memberId`| UUID   | 否   | 會員 ID (方便測試API用)      |
     | `placeId` | String | 是   | Google Place 的唯一識別碼   |
-    | `langType`| String | 是   | 語言類型                   |
   - **請求體範例**:
     ```json
     {
-      "memberId": "550e8400-e29b-41d4-a716-446655440000",
-      "placeId": "ChIJN1t_tDeuEmsRUsoyG83frY4",
-      "langType": "zh-TW"
+      "placeId": "ChIJN1t_tDeuEmsRUsoyG83frY4"
     }
-    ```
+  ```
 - **認證流程**:
   1. 系統會從 `Authorization` header 中提取 Bearer Token
   2. 驗證 Token 的有效性
@@ -546,15 +543,13 @@ const placeDetails = await fetch('/api/search/placeDetails?placeId=ChIJN1t_tDeuE
 // 8. 儲存會員景點
 const saveResult = await fetch('/api/search/saveMemberPoi', {
   method: 'POST',
-  headers: { 
+  headers: {
     'Content-Type': 'application/json',
     'Authorization': 'Bearer ' + accessToken, // 需要有效的 Bearer Token
     'Accept-Language': 'zh-TW'
   },
   body: JSON.stringify({
-    memberId: '550e8400-e29b-41d4-a716-446655440000',
-    placeId: 'ChIJN1t_tDeuEmsRUsoyG83frY4',
-    langType: 'zh-TW'
+    placeId: 'ChIJN1t_tDeuEmsRUsoyG83frY4'
   })
 }).then(res => res.json());
 

--- a/backend/src/main/java/com/travelPlanWithAccounting/service/dto/memberpoi/SaveMemberPoiRequest.java
+++ b/backend/src/main/java/com/travelPlanWithAccounting/service/dto/memberpoi/SaveMemberPoiRequest.java
@@ -4,6 +4,5 @@ import lombok.Data;
 
 @Data
 public class SaveMemberPoiRequest {
-  private String memberId;      // optional, server will validate vs auth
   private String placeId;
 }

--- a/backend/src/main/java/com/travelPlanWithAccounting/service/dto/search/response/PlaceDetailResponse.java
+++ b/backend/src/main/java/com/travelPlanWithAccounting/service/dto/search/response/PlaceDetailResponse.java
@@ -2,6 +2,7 @@ package com.travelPlanWithAccounting.service.dto.search.response;
 
 import com.fasterxml.jackson.databind.JsonNode;
 import java.util.List;
+import java.util.UUID;
 import lombok.*;
 
 @Data
@@ -9,6 +10,7 @@ import lombok.*;
 @AllArgsConstructor
 @Builder
 public class PlaceDetailResponse {
+  private UUID poiId;
   private String placeId;
   private String name;
   private String address;

--- a/backend/src/main/java/com/travelPlanWithAccounting/service/mapper/GooglePlaceDetailMapper.java
+++ b/backend/src/main/java/com/travelPlanWithAccounting/service/mapper/GooglePlaceDetailMapper.java
@@ -109,6 +109,7 @@ public class GooglePlaceDetailMapper {
   // 轉 DB -> PlaceDetailResponse
   public PlaceDetailResponse toDtoFromDb(Poi p, PoiI18n i) {
     return PlaceDetailResponse.builder()
+        .poiId(p.getId())
         .placeId(p.getExternalId())
         .name(i.getName())
         .address(i.getAddress())


### PR DESCRIPTION
## Summary
- include POI database ID in place details response
- remove memberId field from SaveMemberPoiRequest and rely on token member ID
- document updated PlaceDetails and SaveMemberPoi APIs

## Testing
- `mvn -q test` *(fails: Non-resolvable parent POM; network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68a2f7253dc48323a36d06cec6e2e426