### PR TITLE
feat: expose poiId in member POI list

### DIFF
--- a/backend/docs/search.md
+++ b/backend/docs/search.md
@@ -376,6 +376,7 @@ sequenceDiagram
     {
       "list": [
         {
+          "poiId": "43b1ec1f-1234-5678-9abc-def012345678",
           "placeId": "ChIJNw3g1QZePjURMSN68fjJ92o",
           "name": "Yozan Museum",
           "city": "Kagoshima",
@@ -437,6 +438,7 @@ sequenceDiagram
 
 | 欄位      | 型別   | 說明                  |
 |-----------|--------|-----------------------|
+| `poiId`   | String | 會員收藏識別碼，取消收藏時使用（一般搜尋不回傳） |
 | `placeId` | String | Google Places 唯一識別碼 |
 | `name`    | String | 景點名稱              |
 | `city`    | String | 所在城市              |

--- a/backend/src/main/java/com/travelPlanWithAccounting/service/dto/search/response/LocationSearch.java
+++ b/backend/src/main/java/com/travelPlanWithAccounting/service/dto/search/response/LocationSearch.java
@@ -1,9 +1,13 @@
 package com.travelPlanWithAccounting.service.dto.search.response;
 
+import com.fasterxml.jackson.annotation.JsonInclude;
+import java.util.UUID;
 import lombok.Data;
 
+@JsonInclude(JsonInclude.Include.NON_NULL)
 @Data
 public class LocationSearch {
+  private UUID poiId;
   private String placeId;
   private String name;
   private String city;

--- a/backend/src/main/java/com/travelPlanWithAccounting/service/repository/MemberPoiRepository.java
+++ b/backend/src/main/java/com/travelPlanWithAccounting/service/repository/MemberPoiRepository.java
@@ -22,6 +22,7 @@ public interface MemberPoiRepository extends JpaRepository<MemberPoi,UUID> {
       value =
           """
           SELECT p.external_id AS place_id,
+                 mp.poi_id AS poi_id,
                  i.name,
                  i.city_name AS city,
                  (p.photo_urls::json ->> 0) AS photo_url,
@@ -47,6 +48,7 @@ public interface MemberPoiRepository extends JpaRepository<MemberPoi,UUID> {
       Pageable pageable);
 
   interface MemberPoiProjection {
+    UUID getPoiId();
     String getPlaceId();
 
     String getName();

--- a/backend/src/main/java/com/travelPlanWithAccounting/service/service/SearchService.java
+++ b/backend/src/main/java/com/travelPlanWithAccounting/service/service/SearchService.java
@@ -267,6 +267,7 @@ public class SearchService {
             .map(
                 p -> {
                   LocationSearch loc = new LocationSearch();
+                  loc.setPoiId(p.getPoiId());
                   loc.setPlaceId(p.getPlaceId());
                   loc.setName(p.getName());
                   loc.setCity(p.getCity());


### PR DESCRIPTION
## Summary
- include poiId in LocationSearch and omit when null
- return poiId from member POI list query
- document poiId field in LocationSearch and response sample

## Testing
- `mvn -q test` *(fails: Non-resolvable parent POM: Could not transfer artifact org.springframework.boot:spring-boot-starter-parent:pom:3.5.3: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68a30146ac308323baa9d4ec80ab53d7