### PR TITLE
feat: cancel member poi

### DIFF
--- a/backend/docs/search.md
+++ b/backend/docs/search.md
@@ -53,6 +53,7 @@ sequenceDiagram
 | GET    | `/api/search/placeDetails`                | 取得地點詳細資訊 (含照片) |
 | POST   | `/api/search/memberPois`                  | 取得會員收藏景點清單 ⭐ |
 | POST   | `/api/search/saveMemberPoi`               | 儲存會員景點 ⭐          |
+| DELETE | `/api/search/cancelMemberPois`            | 取消會員收藏景點 ⭐      |
 
 ## API 詳細說明
 
@@ -400,6 +401,30 @@ sequenceDiagram
   | `invalid poi type`        | poiType 不在允許範圍 |
   | `invalid max result count`| 每頁筆數不在範圍內   |
   | `invalid page`            | page 必須 >= 1       |
+
+### 12. 取消會員收藏景點 ⭐
+
+- **API**: `DELETE /api/search/cancelMemberPois`
+- **描述**: 取消會員與指定 POI 的關聯
+- **認證**: 需要 Bearer Token 驗證
+- **請求參數**:
+  - **標頭**:
+    | 標頭            | 型別   | 必填 | 說明                    |
+    |-----------------|--------|------|-------------------------|
+    | `Authorization` | String | 是   | Bearer Token 格式       |
+    | `Accept-Language` | String | 否 | 語言類型 (如：zh-TW, en-US) |
+  - **查詢參數**:
+    | 參數   | 型別 | 必填 | 說明        |
+    |--------|------|------|-------------|
+    | `poiId`| UUID | 是   | 收藏景點 ID |
+- **回應**:
+  ```json
+  { "success": true }
+  ```
+- **常見錯誤**:
+  | 錯誤代碼 | 說明               |
+  |----------|--------------------|
+  | `MP-007` | 未找到對應收藏景點 |
 
 ## 共同資料結構
 

--- a/backend/src/main/java/com/travelPlanWithAccounting/service/controller/SearchController.java
+++ b/backend/src/main/java/com/travelPlanWithAccounting/service/controller/SearchController.java
@@ -5,6 +5,7 @@ import com.travelPlanWithAccounting.service.dto.memberpoi.SaveMemberPoiRequest;
 import com.travelPlanWithAccounting.service.dto.memberpoi.SaveMemberPoiResponse;
 import com.travelPlanWithAccounting.service.dto.memberpoi.MemberPoiListRequest;
 import com.travelPlanWithAccounting.service.dto.memberpoi.MemberPoiListResponse;
+import com.travelPlanWithAccounting.service.dto.auth.SimpleResult;
 import com.travelPlanWithAccounting.service.dto.search.request.SearchRequest;
 import com.travelPlanWithAccounting.service.dto.search.request.TextSearchRequest;
 import com.travelPlanWithAccounting.service.dto.search.response.Country;
@@ -21,8 +22,10 @@ import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import java.util.List;
+import java.util.UUID;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
@@ -110,5 +113,12 @@ public class SearchController {
   @Operation(summary = "儲存會員景點（優先取 Access-Token 的 sub）")
   public SaveMemberPoiResponse saveMemberPoi(@Valid @RequestBody SaveMemberPoiRequest req) {
     return searchService.saveMemberPoi(authContext.getCurrentMemberId(), req);
+  }
+
+  @DeleteMapping("/cancelMemberPois")
+  @AccessTokenRequired
+  @Operation(summary = "取消會員收藏景點")
+  public SimpleResult cancelMemberPoi(@RequestParam UUID poiId) {
+    return searchService.cancelMemberPoi(authContext.getCurrentMemberId(), poiId);
   }
 }

--- a/backend/src/main/java/com/travelPlanWithAccounting/service/exception/MemberPoiException.java
+++ b/backend/src/main/java/com/travelPlanWithAccounting/service/exception/MemberPoiException.java
@@ -43,4 +43,10 @@ public class MemberPoiException extends ApiException {
       super(MemberPoiMessageCode.INVALID_PAGE);
     }
   }
+
+  public static class MemberPoiNotFound extends ApiException {
+    public MemberPoiNotFound() {
+      super(MemberPoiMessageCode.MEMBER_POI_NOT_FOUND);
+    }
+  }
 }

--- a/backend/src/main/java/com/travelPlanWithAccounting/service/message/MemberPoiMessageCode.java
+++ b/backend/src/main/java/com/travelPlanWithAccounting/service/message/MemberPoiMessageCode.java
@@ -10,7 +10,8 @@ public enum MemberPoiMessageCode implements MessageCode {
   PLACE_REQUIRED_MISSING("MP-003", HttpStatus.BAD_REQUEST),
   INVALID_POI_TYPE      ("MP-004", HttpStatus.BAD_REQUEST),
   INVALID_MAX_RESULT_COUNT("MP-005", HttpStatus.BAD_REQUEST),
-  INVALID_PAGE          ("MP-006", HttpStatus.BAD_REQUEST);
+  INVALID_PAGE          ("MP-006", HttpStatus.BAD_REQUEST),
+  MEMBER_POI_NOT_FOUND  ("MP-007", HttpStatus.NOT_FOUND);
 
   private final String code;
   private final HttpStatus status;

--- a/backend/src/main/java/com/travelPlanWithAccounting/service/service/SearchService.java
+++ b/backend/src/main/java/com/travelPlanWithAccounting/service/service/SearchService.java
@@ -7,6 +7,7 @@ import com.travelPlanWithAccounting.service.dto.memberpoi.SaveMemberPoiRequest;
 import com.travelPlanWithAccounting.service.dto.memberpoi.SaveMemberPoiResponse;
 import com.travelPlanWithAccounting.service.dto.memberpoi.MemberPoiListRequest;
 import com.travelPlanWithAccounting.service.dto.memberpoi.MemberPoiListResponse;
+import com.travelPlanWithAccounting.service.dto.auth.SimpleResult;
 import com.travelPlanWithAccounting.service.dto.search.request.SearchRequest;
 import com.travelPlanWithAccounting.service.dto.search.request.TextSearchRequest;
 import com.travelPlanWithAccounting.service.dto.search.response.Country;
@@ -18,6 +19,7 @@ import com.travelPlanWithAccounting.service.dto.system.PageMeta;
 import com.travelPlanWithAccounting.service.entity.Location;
 import com.travelPlanWithAccounting.service.entity.Poi;
 import com.travelPlanWithAccounting.service.entity.PoiI18n;
+import com.travelPlanWithAccounting.service.entity.MemberPoi;
 import com.travelPlanWithAccounting.service.entity.TxPoiResult;
 import com.travelPlanWithAccounting.service.entity.TxResult;
 import com.travelPlanWithAccounting.service.exception.MemberException;
@@ -335,6 +337,19 @@ public class SearchService {
         .langInserted(tx.langInserted())
         .alreadySaved(tx.alreadySaved())
         .build();
+  }
+
+  @Transactional
+  public SimpleResult cancelMemberPoi(UUID memberId, UUID poiId) {
+    if (memberId == null) {
+      throw new MemberException.MemberNotFound();
+    }
+    MemberPoi mp =
+        memberPoiRepository
+            .findByMemberIdAndPoi_Id(memberId, poiId)
+            .orElseThrow(MemberPoiException.MemberPoiNotFound::new);
+    memberPoiRepository.delete(mp);
+    return new SimpleResult(true);
   }
 
   @Transactional

--- a/backend/src/main/resources/i18n/messages_en.properties
+++ b/backend/src/main/resources/i18n/messages_en.properties
@@ -60,6 +60,7 @@ MP-003=Place missing required fields
 MP-004=invalid poi type
 MP-005=invalid max result count
 MP-006=invalid page
+MP-007=member poi not found
 RT-001=Refresh token not found
 RT-002=Refresh token invalid
 member.profile.givenName.length=given_name length cannot exceed 30

--- a/backend/src/main/resources/i18n/messages_zh_TW.properties
+++ b/backend/src/main/resources/i18n/messages_zh_TW.properties
@@ -60,6 +60,7 @@ MP-003=地點資料缺少必要欄位
 MP-004=無效的景點類型
 MP-005=無效的每頁筆數
 MP-006=無效的頁數
+MP-007=未找到對應收藏景點
 RT-001=找不到 Refresh Token
 RT-002=Refresh Token 無效
 member.profile.givenName.length=given_name 長度不可超過30


### PR DESCRIPTION
## Summary
- add endpoint to allow members to delete saved POIs
- handle missing member-poi relations with new MP-007 error code
- document cancel member POI API and messages

## Testing
- `mvn -q test` *(fails: Non-resolvable parent POM due to network unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68a304153ecc83238b43db6b8e3e2296