### PR TITLE
Fix recommendation photo URL handling

### DIFF
--- a/backend/docs/recommand-api.md
+++ b/backend/docs/recommand-api.md
@@ -59,7 +59,7 @@ Accept-Language: zh-TW
     "name": "台北 101",
     "country" : "台灣",
     "city": "台北市",
-    "photoUrl": "https://maps.googleapis.com/maps/api/place/photo?maxwidth=400&photo_reference=...",
+    "photoUrl": "https://places.googleapis.com/v1/places/{placeId}/photos/{photoReference}/media?maxWidthPx=400&key=API_KEY",
     "rating": 4.5,
     "reviewCount": 31245,
     "lat": 25.0330,
@@ -71,7 +71,7 @@ Accept-Language: zh-TW
     "name": "國立故宮博物院",
     "country" : "台灣",
     "city": "台北市",
-    "photoUrl": "https://maps.googleapis.com/maps/api/place/photo?maxwidth=400&photo_reference=...",
+    "photoUrl": "https://places.googleapis.com/v1/places/{placeId}/photos/{photoReference}/media?maxWidthPx=400&key=API_KEY",
     "rating": 4.7,
     "reviewCount": 18321,
     "lat": 25.1024,
@@ -91,11 +91,13 @@ Accept-Language: zh-TW
 | name | String | 景點名稱（根據語系顯示） |
 | country | String | 所在國家名稱 |
 | city | String | 所在城市名稱 |
-| photoUrl | String | 景點照片 URL（第一張照片） |
+| photoUrl | String | 景點照片 URL（第一張照片，基於 Places Photos resource name 產生） |
 | rating | Double | 景點評分（1.0-5.0） |
 | reviewCount | Integer | Google Maps 實際評論人數 |
 | lat | Double | 緯度 |
 | lon | Double | 經度 |
+
+> **備註**：若既有資料仍使用舊版 Photo Reference 或快取 URL，需重新呼叫 Places Details 取得 `photos[].name` 以刷新資料。系統會以最新的 Places Photos resource name 生成對應的 media URL。
 
 **錯誤回應欄位**：
 

--- a/backend/docs/search.md
+++ b/backend/docs/search.md
@@ -305,7 +305,7 @@ sequenceDiagram
 ### 9. 取得地點詳細資訊 (含照片)
 
 - **API**: `GET /api/search/placeDetails`
-- **描述**: 根據 Google PlaceId 取得該地點的詳細資訊
+- **描述**: 根據 Google PlaceId 取得該地點的詳細資訊。照片 URL 依 Google Place Photos (New) 格式組出；**photo 的 resource name 會過期**，若回傳來自快取或資料庫，圖片連結可能出現 400（INVALID_ARGUMENT），需重新呼叫本 API 取得最新 place 資料以取得新圖片網址。
 - **請求參數**:
   - **標頭**:
     | 標頭              | 型別   | 必填 | 說明                    |

--- a/backend/src/main/java/com/travelPlanWithAccounting/service/mapper/GooglePlaceDetailMapper.java
+++ b/backend/src/main/java/com/travelPlanWithAccounting/service/mapper/GooglePlaceDetailMapper.java
@@ -2,10 +2,10 @@ package com.travelPlanWithAccounting.service.mapper;
 
 import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.JsonNode;
-import com.travelPlanWithAccounting.service.config.GoogleApiConfig;
 import com.travelPlanWithAccounting.service.dto.search.response.PlaceDetailResponse;
 import com.travelPlanWithAccounting.service.entity.Poi;
 import com.travelPlanWithAccounting.service.entity.PoiI18n;
+import com.travelPlanWithAccounting.service.util.GooglePhotoUrlBuilder;
 import com.travelPlanWithAccounting.service.util.JsonHelper;
 import java.util.ArrayList;
 import java.util.List;
@@ -17,7 +17,7 @@ import org.springframework.stereotype.Component;
 @RequiredArgsConstructor
 public class GooglePlaceDetailMapper {
 
-  private final GoogleApiConfig googleApiConfig;
+  private final GooglePhotoUrlBuilder photoUrlBuilder;
   private final JsonHelper jsonHelper;
 
   public PlaceDetailResponse toDto(JsonNode p, boolean withDetails) {
@@ -63,7 +63,7 @@ public class GooglePlaceDetailMapper {
     JsonNode photoArr = p.path("photos");
     for (int i = 0; i < photoArr.size() && i < 5; i++) {
       String photoName = photoArr.get(i).path("name").asText();
-      photos.add(buildPhotoUrl(photoName, 400)); // 400px 預設，可依需求 param
+      photos.add(photoUrlBuilder.buildFromName(photoName, 400)); // 400px 預設，可依需求 param
     }
 
     /* ======== regularOpeningHours 原始 JSON ======== */
@@ -95,15 +95,6 @@ public class GooglePlaceDetailMapper {
         .primaryType(primaryType)
         .rawJson(withDetails ? p : null) // 整包資料
         .build();
-  }
-
-  private String buildPhotoUrl(String photoName, int maxWidthPx) {
-    return "https://places.googleapis.com/v1/"
-        + photoName
-        + "/media?key="
-        + googleApiConfig.getGoogleApiKey()
-        + "&maxWidthPx="
-        + maxWidthPx;
   }
 
   // 轉 DB -> PlaceDetailResponse

--- a/backend/src/main/java/com/travelPlanWithAccounting/service/mapper/GooglePlaceMapper.java
+++ b/backend/src/main/java/com/travelPlanWithAccounting/service/mapper/GooglePlaceMapper.java
@@ -3,7 +3,7 @@ package com.travelPlanWithAccounting.service.mapper;
 import static com.travelPlanWithAccounting.service.util.GooglePlaceConstants.*;
 
 import com.fasterxml.jackson.databind.JsonNode;
-import com.travelPlanWithAccounting.service.config.GoogleApiConfig;
+import com.travelPlanWithAccounting.service.util.GooglePhotoUrlBuilder;
 import com.travelPlanWithAccounting.service.dto.search.response.LocationSearch;
 import java.util.*;
 import org.springframework.stereotype.Component;
@@ -11,10 +11,10 @@ import org.springframework.stereotype.Component;
 @Component
 public class GooglePlaceMapper {
 
-  private final GoogleApiConfig googleApiConfig;
+  private final GooglePhotoUrlBuilder photoUrlBuilder;
 
-  public GooglePlaceMapper(GoogleApiConfig googleApiConfig) {
-    this.googleApiConfig = googleApiConfig;
+  public GooglePlaceMapper(GooglePhotoUrlBuilder photoUrlBuilder) {
+    this.photoUrlBuilder = photoUrlBuilder;
   }
 
   public List<LocationSearch> toLocationSearchList(JsonNode root) {
@@ -37,12 +37,7 @@ public class GooglePlaceMapper {
     JsonNode photosNode = place.path("photos");
     if (photosNode.isArray() && photosNode.size() > 0) {
       String photoName = photosNode.get(0).path("name").asText();
-      photoUrl =
-          "https://places.googleapis.com/v1/"
-              + photoName
-              + "/media?key="
-              + googleApiConfig.getGoogleApiKey()
-              + "&maxWidthPx=400";
+      photoUrl = photoUrlBuilder.buildFromName(photoName, 400);
     }
 
     // City 決策

--- a/backend/src/main/java/com/travelPlanWithAccounting/service/service/RecommandService.java
+++ b/backend/src/main/java/com/travelPlanWithAccounting/service/service/RecommandService.java
@@ -10,6 +10,7 @@ import com.travelPlanWithAccounting.service.exception.RecommandException;
 import com.travelPlanWithAccounting.service.repository.PoiRepository;
 import com.travelPlanWithAccounting.service.repository.PoiRepository.LocationSummary;
 import com.travelPlanWithAccounting.service.repository.PoiRepository.PoiExternalId;
+import com.travelPlanWithAccounting.service.util.GooglePhotoUrlBuilder;
 import com.travelPlanWithAccounting.service.util.LangTypeMapper;
 import java.io.IOException;
 import java.io.InputStream;
@@ -56,6 +57,7 @@ public class RecommandService {
   private final SearchService searchService;
   private final ResourceLoader resourceLoader;
   private final ObjectMapper objectMapper;
+  private final GooglePhotoUrlBuilder photoUrlBuilder;
 
   private final ConcurrentMap<String, List<RecommandDefinition>> cache = new ConcurrentHashMap<>();
 
@@ -239,13 +241,19 @@ public class RecommandService {
         return null;
       }
       if (first.isTextual()) {
-        return first.asText();
+        return photoUrlBuilder.resolvePhotoUrl(first.asText(), 400);
+      }
+      if (first.hasNonNull("name")) {
+        return photoUrlBuilder.buildFromName(first.get("name").asText(), 400);
+      }
+      if (first.hasNonNull("urlSmall")) {
+        return photoUrlBuilder.resolvePhotoUrl(first.get("urlSmall").asText(), 400);
       }
       if (first.hasNonNull("url")) {
-        return first.get("url").asText();
+        return photoUrlBuilder.resolvePhotoUrl(first.get("url").asText(), 400);
       }
       if (first.hasNonNull("photoUrl")) {
-        return first.get("photoUrl").asText();
+        return photoUrlBuilder.resolvePhotoUrl(first.get("photoUrl").asText(), 400);
       }
     } catch (IOException e) {
       log.warn("Failed to parse photoUrls JSON for poi {}", photoJson, e);

--- a/backend/src/main/java/com/travelPlanWithAccounting/service/service/RecommandService.java
+++ b/backend/src/main/java/com/travelPlanWithAccounting/service/service/RecommandService.java
@@ -170,7 +170,9 @@ public class RecommandService {
         result.add(refreshed);
         continue;
       }
-      result.add(toDto(summary));
+      // 推薦列表的 photoUrl 須為未過期的 resource，故跳過快取向 Google 取最新 Place Details 的第一張圖
+      String freshPhotoUrl = getFreshPhotoUrl(summary.getExternalId());
+      result.add(toDto(summary, freshPhotoUrl));
     }
 
     if (result.size() < limit) {
@@ -195,13 +197,23 @@ public class RecommandService {
   }
 
   private LocationRecommand toDto(LocationSummary summary) {
+    return toDto(summary, null);
+  }
+
+  /**
+   * 組裝推薦 DTO；photoUrlOverride 為 null 時使用 DB 的 photoUrls（可能過期）。
+   * 推薦 API 應傳入由 Place Details 取得之未過期 photo URL。
+   */
+  private LocationRecommand toDto(LocationSummary summary, String photoUrlOverride) {
+    String photoUrl =
+        photoUrlOverride != null ? photoUrlOverride : extractFirstPhoto(summary.getPhotoUrls());
     return LocationRecommand.builder()
         .poiId(summary.getId())
         .placeId(summary.getExternalId())
         .name(summary.getName())
         .country(summary.getCountryName())
         .city(summary.getCityName())
-        .photoUrl(extractFirstPhoto(summary.getPhotoUrls()))
+        .photoUrl(photoUrl)
         .rating(toDouble(summary.getRating()))
         .reviewCount(summary.getReviewCount())
         .lat(toDouble(summary.getLat()))
@@ -318,6 +330,23 @@ public class RecommandService {
     }
     return poiRepository.findAllExternalIdsByIdIn(poiIds).stream()
         .collect(Collectors.toMap(PoiExternalId::getId, PoiExternalId::getExternalId));
+  }
+
+  /** 向 Place Details 取最新資料（跳過快取），取得未過期的第一張 photo URL；失敗時回傳 null。 */
+  private String getFreshPhotoUrl(String placeId) {
+    if (placeId == null || placeId.isBlank()) {
+      return null;
+    }
+    try {
+      PlaceDetailResponse detail = searchService.getPlaceDetailById(placeId, false);
+      if (detail == null || detail.getPhotoUrls() == null || detail.getPhotoUrls().isEmpty()) {
+        return null;
+      }
+      return detail.getPhotoUrls().get(0);
+    } catch (RuntimeException ex) {
+      log.warn("Failed to get fresh photo URL for placeId={}", placeId, ex);
+      return null;
+    }
   }
 
   private LocationRecommand refreshFromPlaceDetails(

--- a/backend/src/main/java/com/travelPlanWithAccounting/service/service/SearchService.java
+++ b/backend/src/main/java/com/travelPlanWithAccounting/service/service/SearchService.java
@@ -243,22 +243,34 @@ public class SearchService {
   }
 
   /**
-   * 根據 placeId 查詢完整景點
+   * 根據 placeId 查詢完整景點（會使用 24h 快取）。
    *
    * @param placeId Google Map placeId
-   * @param langType 語系
    * @return PlaceDetailResponse
    */
   @Transactional
   public PlaceDetailResponse getPlaceDetailById(String placeId) {
+    return getPlaceDetailById(placeId, true);
+  }
+
+  /**
+   * 根據 placeId 查詢完整景點。
+   *
+   * @param placeId Google Map placeId
+   * @param useCache 是否使用 24h 快取；false 時強制呼叫 Google API，可取得未過期的 photo resource
+   * @return PlaceDetailResponse
+   */
+  @Transactional
+  public PlaceDetailResponse getPlaceDetailById(String placeId, boolean useCache) {
     String langType = LocaleContextHolder.getLocale().toLanguageTag();
 
     // 1) 驗證
     placeDetailValidator.validate(placeId, langType);
     String langCode = langTypeMapper.toCode(langType);
 
-    // 2) 先找 DB（替換原本的 infos_raw 快取）
-    Optional<String> cachedJson = poiRepository.findCachedRawJson(placeId, langCode);
+    // 2) 依 useCache 決定是否讀快取；推薦列表需未過期 photo URL 時傳 useCache=false
+    Optional<String> cachedJson =
+        useCache ? poiRepository.findCachedRawJson(placeId, langCode) : Optional.empty();
     JsonNode json;
     boolean hit = cachedJson.isPresent();
     UUID poiId = null;
@@ -269,7 +281,7 @@ public class SearchService {
       poiId =
           poiRepository.findByExternalId(placeId).map(p -> p.getId()).orElse(null);
     } else {
-      log.debug("Call api placeId={} langType={}", placeId, langType);
+      log.debug("Call api placeId={} langType={} useCache={}", placeId, langType, useCache);
       PlaceDetailRequestPost req = requestFactory.buildPlaceDetails(placeId);
       json = mapService.getPlaceDetails(req);
 

--- a/backend/src/main/java/com/travelPlanWithAccounting/service/util/GooglePhotoUrlBuilder.java
+++ b/backend/src/main/java/com/travelPlanWithAccounting/service/util/GooglePhotoUrlBuilder.java
@@ -16,15 +16,26 @@ public class GooglePhotoUrlBuilder {
     this.googleApiConfig = googleApiConfig;
   }
 
+  /**
+   * 建構 Place Photos (New) 的 media URL。
+   * 官方格式：https://places.googleapis.com/v1/NAME/media?key=API_KEY&maxWidthPx=...&maxHeightPx=...
+   * NAME 須為 photos[].name（格式 places/PLACE_ID/photos/PHOTO_REFERENCE），且會過期，勿快取。
+   */
   public String buildFromName(String photoName, int maxWidthPx) {
     if (photoName == null || photoName.isBlank()) {
       return null;
     }
+    String name = normalizePhotoResourceName(photoName);
+    if (name == null) {
+      return null;
+    }
     return "https://places.googleapis.com/v1/"
-        + photoName
+        + name
         + "/media?key="
         + googleApiConfig.getGoogleApiKey()
         + "&maxWidthPx="
+        + maxWidthPx
+        + "&maxHeightPx="
         + maxWidthPx;
   }
 
@@ -41,9 +52,6 @@ public class GooglePhotoUrlBuilder {
 
   private String extractPhotoName(String value) {
     String trimmed = value.trim();
-    if (trimmed.startsWith(PHOTO_RESOURCE_PREFIX)) {
-      return trimmed;
-    }
     int start = trimmed.indexOf(PHOTO_RESOURCE_PREFIX);
     if (start < 0 || !trimmed.contains(PHOTO_RESOURCE_MARKER)) {
       return null;
@@ -58,6 +66,34 @@ public class GooglePhotoUrlBuilder {
     if (end <= start) {
       return null;
     }
-    return trimmed.substring(start, end);
+    return normalizePhotoResourceName(trimmed.substring(start, end));
+  }
+
+  /**
+   * 正規化為 Place Photos (New) 的 resource name：places/PLACE_ID/photos/PHOTO_REFERENCE，
+   * 不含 /media 與 query string，避免組出無效 URL。
+   */
+  private String normalizePhotoResourceName(String value) {
+    if (value == null || value.isBlank()) {
+      return null;
+    }
+    String s = value.trim();
+    if (!s.contains(PHOTO_RESOURCE_PREFIX) || !s.contains(PHOTO_RESOURCE_MARKER)) {
+      return null;
+    }
+    int start = s.indexOf(PHOTO_RESOURCE_PREFIX);
+    int mediaIdx = s.indexOf(MEDIA_SEGMENT, start);
+    int qIdx = s.indexOf('?', start);
+    int end = s.length();
+    if (mediaIdx > start) {
+      end = mediaIdx;
+    }
+    if (qIdx > start && qIdx < end) {
+      end = qIdx;
+    }
+    if (end <= start) {
+      return null;
+    }
+    return s.substring(start, end);
   }
 }

--- a/backend/src/main/java/com/travelPlanWithAccounting/service/util/GooglePhotoUrlBuilder.java
+++ b/backend/src/main/java/com/travelPlanWithAccounting/service/util/GooglePhotoUrlBuilder.java
@@ -1,0 +1,63 @@
+package com.travelPlanWithAccounting.service.util;
+
+import com.travelPlanWithAccounting.service.config.GoogleApiConfig;
+import org.springframework.stereotype.Component;
+
+@Component
+public class GooglePhotoUrlBuilder {
+
+  private static final String PHOTO_RESOURCE_PREFIX = "places/";
+  private static final String PHOTO_RESOURCE_MARKER = "/photos/";
+  private static final String MEDIA_SEGMENT = "/media";
+
+  private final GoogleApiConfig googleApiConfig;
+
+  public GooglePhotoUrlBuilder(GoogleApiConfig googleApiConfig) {
+    this.googleApiConfig = googleApiConfig;
+  }
+
+  public String buildFromName(String photoName, int maxWidthPx) {
+    if (photoName == null || photoName.isBlank()) {
+      return null;
+    }
+    return "https://places.googleapis.com/v1/"
+        + photoName
+        + "/media?key="
+        + googleApiConfig.getGoogleApiKey()
+        + "&maxWidthPx="
+        + maxWidthPx;
+  }
+
+  public String resolvePhotoUrl(String value, int maxWidthPx) {
+    if (value == null || value.isBlank()) {
+      return null;
+    }
+    String photoName = extractPhotoName(value);
+    if (photoName != null) {
+      return buildFromName(photoName, maxWidthPx);
+    }
+    return value;
+  }
+
+  private String extractPhotoName(String value) {
+    String trimmed = value.trim();
+    if (trimmed.startsWith(PHOTO_RESOURCE_PREFIX)) {
+      return trimmed;
+    }
+    int start = trimmed.indexOf(PHOTO_RESOURCE_PREFIX);
+    if (start < 0 || !trimmed.contains(PHOTO_RESOURCE_MARKER)) {
+      return null;
+    }
+    int end = trimmed.indexOf(MEDIA_SEGMENT, start);
+    if (end < 0) {
+      end = trimmed.indexOf('?', start);
+    }
+    if (end < 0) {
+      end = trimmed.length();
+    }
+    if (end <= start) {
+      return null;
+    }
+    return trimmed.substring(start, end);
+  }
+}


### PR DESCRIPTION
### Motivation
- Users reported `INVALID_ARGUMENT` errors for recommendation `photoUrl` because stored/cached photo values were not always valid Places Photos resource names or media URLs. 
- The intent is to centralize media URL construction and make the recommendation endpoint resilient to both new Places v1 photo resource names and older/cached URL formats.

### Description
- Add `GooglePhotoUrlBuilder` to centralize logic for building/resolving Places Photos media URLs from `photos[].name` or existing cached values (`backend/.../GooglePhotoUrlBuilder.java`).
- Update `GooglePlaceMapper` and `GooglePlaceDetailMapper` to use the new builder for constructing photo media URLs when mapping Places API responses (`backend/.../GooglePlaceMapper.java`, `backend/.../GooglePlaceDetailMapper.java`).
- Make `RecommandService` photo extraction resilient by resolving textual entries, object fields (`name`, `urlSmall`, `url`, `photoUrl`) and rebuilding valid media URLs when possible (`backend/.../RecommandService.java`).
- Update API docs to show the Places Photos media URL pattern and add a note recommending refreshing cached photo metadata via Place Details to obtain `photos[].name` (`backend/docs/recommand-api.md`).

### Testing
- Ran `mvn clean install` to validate compilation and test suite, but the build failed due to inability to download the parent POM from Maven Central (HTTP 403) in this environment, so full build/test verification could not be completed. 
- Attempted to fetch Google Photos docs from developers.google.com but received HTTP 403 from this environment, so external docs checks were limited.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697d57e733b483238485819dd553bc67)