### PR TITLE
Refresh expired Google Places photo URLs

### DIFF
--- a/backend/src/main/java/com/travelPlanWithAccounting/service/service/SearchService.java
+++ b/backend/src/main/java/com/travelPlanWithAccounting/service/service/SearchService.java
@@ -40,6 +40,7 @@ import com.travelPlanWithAccounting.service.util.GooglePlaceConstants;
 import com.travelPlanWithAccounting.service.util.JsonHelper;
 import com.travelPlanWithAccounting.service.util.LangTypeMapper;
 import com.travelPlanWithAccounting.service.util.LocationHelper;
+import com.travelPlanWithAccounting.service.util.PhotoUrlValidator;
 import com.travelPlanWithAccounting.service.util.PoiTypeMapper;
 import com.travelPlanWithAccounting.service.validator.PlaceDetailValidator;
 import com.travelPlanWithAccounting.service.validator.MemberPoiListValidator;
@@ -104,6 +105,7 @@ public class SearchService {
   @Autowired private JsonHelper jsonHelper;
   @Autowired private MemberPoiListValidator memberPoiListValidator;
   @Autowired private MemberPoiFavoritesValidator memberPoiFavoritesValidator;
+  @Autowired private PhotoUrlValidator photoUrlValidator;
 
   public List<Region> searchRegions(String countryCode) {
     String langType = LocaleContextHolder.getLocale().toLanguageTag();
@@ -293,7 +295,30 @@ public class SearchService {
 
     PlaceDetailResponse resp = placeDetailMapper.toDto(json, false);
     resp.setPoiId(poiId);
+    if (useCache) {
+      resp = refreshPhotoUrlIfExpired(resp, langCode);
+    }
     return resp;
+  }
+
+  private PlaceDetailResponse refreshPhotoUrlIfExpired(
+      PlaceDetailResponse cached, String langCode) {
+    if (cached == null || cached.getPhotoUrls() == null || cached.getPhotoUrls().isEmpty()) {
+      return cached;
+    }
+    String firstPhotoUrl = cached.getPhotoUrls().get(0);
+    if (photoUrlValidator.isValid(firstPhotoUrl)) {
+      return cached;
+    }
+    log.info(
+        "Detected expired photo URL for placeId={}, refreshing from Google.",
+        cached.getPlaceId());
+    PlaceDetailRequestPost req = requestFactory.buildPlaceDetails(cached.getPlaceId());
+    JsonNode freshJson = mapService.getPlaceDetails(req);
+    PlaceDetailResponse freshDto = placeDetailMapper.toDto(freshJson, false);
+    TxPoiResult tx = upsertPoiAndI18n(freshDto, langCode);
+    freshDto.setPoiId(tx.getPoiId());
+    return freshDto;
   }
 
   public MemberPoiListResponse getMemberPoiList(UUID memberId, MemberPoiListRequest req) {
@@ -322,7 +347,7 @@ public class SearchService {
                   loc.setPlaceId(p.getPlaceId());
                   loc.setName(p.getName());
                   loc.setCity(p.getCity());
-                  loc.setPhotoUrl(p.getPhotoUrl());
+                  loc.setPhotoUrl(resolveValidPhotoUrl(p.getPlaceId(), p.getPhotoUrl()));
                   loc.setRating(p.getRating());
                   return loc;
                 })
@@ -342,6 +367,23 @@ public class SearchService {
     resp.setList(list);
     resp.setMeta(meta);
     return resp;
+  }
+
+  private String resolveValidPhotoUrl(String placeId, String photoUrl) {
+    if (photoUrlValidator.isValid(photoUrl)) {
+      return photoUrl;
+    }
+    log.info(
+        "Detected expired photo URL for placeId={}, refreshing from Google.", placeId);
+    try {
+      PlaceDetailResponse detail = getPlaceDetailById(placeId, false);
+      if (detail != null && detail.getPhotoUrls() != null && !detail.getPhotoUrls().isEmpty()) {
+        return detail.getPhotoUrls().get(0);
+      }
+    } catch (RuntimeException ex) {
+      log.warn("Failed to refresh photo URL for placeId={}", placeId, ex);
+    }
+    return photoUrl;
   }
 
   public Map<String, Boolean> checkPoisFavorites(UUID memberId, List<String> placeIds) {

--- a/backend/src/main/java/com/travelPlanWithAccounting/service/util/PhotoUrlValidator.java
+++ b/backend/src/main/java/com/travelPlanWithAccounting/service/util/PhotoUrlValidator.java
@@ -1,0 +1,44 @@
+package com.travelPlanWithAccounting.service.util;
+
+import java.net.URI;
+import java.net.http.HttpClient;
+import java.net.http.HttpRequest;
+import java.net.http.HttpResponse;
+import java.time.Duration;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Component;
+
+@Component
+@Slf4j
+public class PhotoUrlValidator {
+
+  private static final int VALID_STATUS_MAX = 400;
+  private static final Duration REQUEST_TIMEOUT = Duration.ofSeconds(5);
+
+  private final HttpClient httpClient;
+
+  public PhotoUrlValidator(HttpClient httpClient) {
+    this.httpClient = httpClient;
+  }
+
+  public boolean isValid(String url) {
+    if (url == null || url.isBlank()) {
+      return false;
+    }
+    try {
+      HttpRequest request =
+          HttpRequest.newBuilder()
+              .uri(URI.create(url))
+              .timeout(REQUEST_TIMEOUT)
+              .method("HEAD", HttpRequest.BodyPublishers.noBody())
+              .build();
+      HttpResponse<Void> response =
+          httpClient.send(request, HttpResponse.BodyHandlers.discarding());
+      int statusCode = response.statusCode();
+      return statusCode >= 200 && statusCode < VALID_STATUS_MAX;
+    } catch (Exception ex) {
+      log.warn("Failed to validate photo URL: {}", url, ex);
+      return false;
+    }
+  }
+}


### PR DESCRIPTION
### Motivation
- DB stores Google Place photo URLs which can expire, causing broken images in saved POIs and recommendation lists.
- The goal is to detect expired photo URLs and refresh them from the Google Places `Place Details` API and update the DB automatically.

### Description
- Added `PhotoUrlValidator` (`backend/src/main/java/com/travelPlanWithAccounting/service/util/PhotoUrlValidator.java`) which performs a `HEAD` request to validate a photo URL's HTTP status.
- Updated `SearchService.getPlaceDetailById` to, when returning cached entries, check the first photo URL and re-fetch fresh `Place Details` from Google and `upsertPoiAndI18n` if the URL is invalid.
- Added `resolveValidPhotoUrl` in `SearchService` and used it when building member POI lists so expired photo URLs are detected and replaced by the freshly fetched first photo when possible.
- Wired `PhotoUrlValidator` into `SearchService` via injection and used existing `mapService`/`placeDetailMapper`/`upsertPoiAndI18n` flow to persist refreshed data.

### Testing
- Executed `mvn clean install` as the automated build verification but it failed due to inability to download the Spring Boot parent POM from Maven central (HTTP 403), so compilation/tests could not be completed.
- Local file edits and commits were performed and staged changes include `PhotoUrlValidator` and modifications to `SearchService`; no automated unit tests ran successfully due to the Maven repository access error.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697d5fe5f71c8323a16ab3e93e6075c5)