### PR TITLE
Upgrade backend to JDK 25 and Spring Boot 4 (update Docker, build scripts, and docs)

### DIFF
--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -1,11 +1,11 @@
 # 構建階段
-FROM eclipse-temurin:21-jre-alpine AS builder
+FROM eclipse-temurin:25-jre-alpine AS builder
 WORKDIR /application/jar
 COPY target/*.jar application.jar
 RUN java -Djarmode=layertools -jar application.jar extract
 
 # 運行階段
-FROM eclipse-temurin:21-jre-alpine
+FROM eclipse-temurin:25-jre-alpine
 RUN apk add --no-cache bash
 WORKDIR /application
 # 複製分層構建的結果

--- a/backend/README.md
+++ b/backend/README.md
@@ -2,8 +2,8 @@
 
 ## 環境需求
 
-- **OpenJDK 21.0.6 LTS**  
-  [下載連結](https://learn.microsoft.com/en-us/java/openjdk/download#openjdk-21)
+- **OpenJDK 25**  
+  [下載連結](https://learn.microsoft.com/en-us/java/openjdk/download)
 - **Maven 3.9.9**  
   [下載連結](https://maven.apache.org/download.cgi)
 

--- a/backend/build.bat
+++ b/backend/build.bat
@@ -40,12 +40,12 @@ REM Convert Windows path to Docker path format
 set "HOST_DIR_DOCKER=%HOST_DIR:\=/%"
 
 REM Use Docker to extract artifactId
-for /f "tokens=*" %%a in ('docker run --rm -v "%HOST_DIR_DOCKER%:/app" -w "%CONTAINER_WORKDIR%" maven:3.9.9-eclipse-temurin-21 mvn help:evaluate -Dexpression^=project.artifactId -q -DforceStdout') do (
+for /f "tokens=*" %%a in ('docker run --rm -v "%HOST_DIR_DOCKER%:/app" -w "%CONTAINER_WORKDIR%" maven:3.9.9-eclipse-temurin-25 mvn help:evaluate -Dexpression^=project.artifactId -q -DforceStdout') do (
     set "APP_NAME=%%a"
 )
 
 REM Use Docker to extract version
-for /f "tokens=*" %%a in ('docker run --rm -v "%HOST_DIR_DOCKER%:/app" -w "%CONTAINER_WORKDIR%" maven:3.9.9-eclipse-temurin-21 mvn help:evaluate -Dexpression^=project.version -q -DforceStdout') do (
+for /f "tokens=*" %%a in ('docker run --rm -v "%HOST_DIR_DOCKER%:/app" -w "%CONTAINER_WORKDIR%" maven:3.9.9-eclipse-temurin-25 mvn help:evaluate -Dexpression^=project.version -q -DforceStdout') do (
     set "VERSION=%%a"
 )
 
@@ -65,7 +65,7 @@ set "IMAGE_NAME=!APP_NAME!:!VERSION!"
 echo [SUCCESS] Project info: name=!APP_NAME!, version=!VERSION!, JAR=!JAR_NAME!
 
 echo [INFO] Building Maven project...
-docker run --rm -v "%HOST_DIR_DOCKER%:/app" -w "%CONTAINER_WORKDIR%" maven:3.9.9-eclipse-temurin-21 mvn clean package -DskipTests
+docker run --rm -v "%HOST_DIR_DOCKER%:/app" -w "%CONTAINER_WORKDIR%" maven:3.9.9-eclipse-temurin-25 mvn clean package -DskipTests
 
 if %ERRORLEVEL% NEQ 0 (
     echo [ERROR] Maven build failed

--- a/backend/build.sh
+++ b/backend/build.sh
@@ -1,12 +1,12 @@
 #!/bin/bash
 
 # 腳本名稱: build.sh
-# 用途: 使用 maven:3.9.9-eclipse-temurin-21 容器打包 Maven 專案，構建 Docker 鏡像，支援 monorepo 結構查找 pom.xml 和 Dockerfile，動態查找 .backendEnv
+# 用途: 使用 maven:3.9.9-eclipse-temurin-25 容器打包 Maven 專案，構建 Docker 鏡像，支援 monorepo 結構查找 pom.xml 和 Dockerfile，動態查找 .backendEnv
 # 使用方式: chmod +x build.sh && ./build.sh
 
 # 配置參數
 DOCKERFILE="Dockerfile"
-MAVEN_IMAGE="maven:3.9.9-eclipse-temurin-21"
+MAVEN_IMAGE="maven:3.9.9-eclipse-temurin-25"
 
 # 顏色輸出函數
 RED='\033[0;31m'

--- a/backend/docs/jdk25-springboot4-upgrade-plan.md
+++ b/backend/docs/jdk25-springboot4-upgrade-plan.md
@@ -1,0 +1,105 @@
+# JDK 25 + Spring Boot 4.0 升級計畫書
+
+## 1. 目標與範圍
+- **目標**：將後端服務升級至 JDK 25 與 Spring Boot 4.0，維持現有 API 行為與資料庫相容性。
+- **範圍**：
+  - Maven 建置與執行環境
+  - Spring Boot 與相關相依套件
+  - Docker/Docker Compose 映像與啟動流程
+  - CI/CD（如有）之建置與測試流程
+
+## 2. 現況盤點（基準資訊）
+- **JDK**：`java.version=25`（`pom.xml`）
+- **Spring Boot**：`4.0.0`（`spring-boot-starter-parent`）
+- **Docker Base Image**：`eclipse-temurin:25-jre-alpine`（建置/運行）
+- **關鍵相依**：
+  - `springdoc-openapi`：`3.0.0`
+  - `jjwt`：`0.13.0`
+  - `Apache HttpClient`：`4.5.14`
+
+> 上述資訊作為升級前基準點，升級後需重新驗證行為與相容性。
+
+## 3. 風險與前置確認
+1. **Spring Boot 4.0 相容性**
+   - 確認 Spring Boot 4.0 的正式版與維護策略。
+   - 檢查 Boot 4 對 Jakarta EE 版本（例如 Jakarta EE 11）要求與 API 變更。
+2. **JDK 25 支援度**
+   - 確認 JDK 25 是否為團隊可接受的版本（LTS 與否）。
+   - 確認部署環境與第三方服務對 JDK 25 的支援狀況。
+3. **依賴套件升級影響**
+   - 核心依賴（springdoc、jjwt、Apache HttpClient 等）需確認支援 Boot 4。
+   - 驗證序列化、Hibernate/JPA、Spring Security 版本差異。
+
+## 4. 應用程式層面變更（預估）
+### 4.1 Maven / Java 設定
+- 更新 `pom.xml`：
+  - `spring-boot-starter-parent` 升級至 4.0.x。
+  - `maven-compiler-plugin` 與 `java.version` 設定為 25。
+  - 若使用 Maven Toolchains，新增/更新 JDK 25 toolchain。
+
+### 4.2 Spring Boot 與依賴套件
+- 依賴版本需配合 Boot 4 BOM，若有手動鎖版請逐一檢查相容性。
+- 重點檢查清單：
+  - **springdoc-openapi**：確認支援 Boot 4 的版本與設定變更。
+  - **jjwt**：驗證 API/配置變動、key format 相容性。
+  - **Apache HttpClient**：確認 4.x/5.x 的支援策略，必要時升級。
+  - **Hibernate/JPA**：確認 Jakarta EE 版本與 dialect 行為變化。
+  - **Spring Security**：檢視 SecurityFilterChain、Csrf、Matchers 行為是否變更。
+
+### 4.3 程式碼與設定檔調整
+- 搜尋是否存在已棄用 API（例如 Spring Boot 4 移除的配置）。
+- 確認 `application-*.yml` 設定是否需改名或語意改變。
+- 若 Boot 4 需要 Jakarta EE 11：
+  - 確認所有 `jakarta.*` 套件引用一致。
+  - 進行必要的 import/annotation 更新。
+
+## 5. Docker / 部署環境變更（預估）
+### 5.1 Dockerfile
+- 基礎映像更換為 JDK 25：
+  - 例如 `eclipse-temurin:25-jre` 或 `eclipse-temurin:25-jdk`。
+- 若有分離 build/runtime stage：
+  - build stage 使用 JDK 25
+  - runtime stage 使用 JRE 25
+
+### 5.2 docker-compose.yml
+- 更新 image tag 或 build context 對應 JDK 25。
+- 驗證 JVM 參數、記憶體限制與健康檢查。
+
+## 6. 計畫驗證與確認（Review Check）
+### 6.1 版本與相依確認清單
+- [ ] `pom.xml` 中 `spring-boot-starter-parent` 升至 4.0.x。
+- [ ] `java.version` 由 21 改為 25。
+- [ ] `springdoc-openapi` 版本確認支援 Boot 4。
+- [ ] `jjwt` 版本與既有 token 兼容。
+- [ ] `httpclient` 版本評估是否需升級到 5.x。
+- [ ] `Dockerfile` base image 更新為 JDK 25。
+
+### 6.2 設定檔與程式碼檢查
+- [ ] `application-*.yml` 中 Boot 4 移除/改名的設定已調整。
+- [ ] `jakarta.*` 套件引用與 Jakarta EE 版本一致。
+- [ ] SecurityFilterChain / WebSecurityConfigurer 變更已對應更新。
+
+### 6.3 驗證流程（建議檢查指令）
+- [ ] `mvn clean install` 或 `./mvnw clean install` 通過。
+- [ ] `docker build` 可建立映像且正常啟動。
+- [ ] 基本 API（登入、行程、熱門景點）可通過冒煙測試。
+- [ ] JWT 驗證流程未破壞（AccessTokenAspect / JwtUtil 正常）。
+
+## 7. 測試與驗證計畫
+1. **編譯與單元測試**
+   - `mvn clean install` 或 `./mvnw clean install`
+2. **啟動與冒煙測試**
+   - 檢查健康檢查、主要 API 端點與 JWT 驗證流程。
+3. **回歸測試**
+   - 針對關鍵流程：會員登入、行程查詢、熱門景點等。
+
+## 8. 交付與里程碑
+1. **調查與版本評估**（1~2 天）
+2. **升級與修正**（2~4 天）
+3. **測試與回歸**（1~3 天）
+4. **正式部署**（與維運窗口協調）
+
+## 9. 交付物
+- 變更後的 `pom.xml`、`Dockerfile`、`docker-compose.yml`
+- 測試報告與驗證紀錄
+- 升級說明文件（本文件更新為最終版）

--- a/backend/pom.xml
+++ b/backend/pom.xml
@@ -6,7 +6,7 @@
 	<parent>
 		<groupId>org.springframework.boot</groupId>
 		<artifactId>spring-boot-starter-parent</artifactId>
-		<version>3.5.6</version>
+		<version>4.0.0</version>
 		<relativePath /> <!-- lookup parent from repository -->
 	</parent>
 	<groupId>com.travelPlanWithAccounting</groupId>
@@ -28,8 +28,8 @@
 		<url />
 	</scm>
 	<properties>
-		<java.version>21</java.version>
-		<springdoc.version>2.8.6</springdoc.version>
+		<java.version>25</java.version>
+		<springdoc.version>3.0.0</springdoc.version>
 	</properties>
 	<dependencies>
 		<dependency>

--- a/backend/pom.xml
+++ b/backend/pom.xml
@@ -30,6 +30,7 @@
 	<properties>
 		<java.version>25</java.version>
 		<springdoc.version>3.0.0</springdoc.version>
+		<lombok.version>1.18.42</lombok.version>
 	</properties>
 	<dependencies>
 		<dependency>
@@ -42,9 +43,10 @@
 				<artifactId>spring-boot-starter-web</artifactId>
 		</dependency>
 
+		<!-- Spring Boot 4.0: spring-boot-starter-aop 已更名為 spring-boot-starter-aspectj -->
 		<dependency>
 				<groupId>org.springframework.boot</groupId>
-				<artifactId>spring-boot-starter-aop</artifactId>
+				<artifactId>spring-boot-starter-aspectj</artifactId>
 		</dependency>
 
 		<dependency>
@@ -78,6 +80,8 @@
 		<dependency>
 			<groupId>org.projectlombok</groupId>
 			<artifactId>lombok</artifactId>
+			<version>${lombok.version}</version>
+			<scope>provided</scope>
 			<optional>true</optional>
 		</dependency>
 
@@ -150,6 +154,24 @@
 
 	<build>
 		<plugins>
+			<!-- JDK 23+ 預設不執行 annotation processor，必須明確設定 Lombok -->
+			<plugin>
+				<groupId>org.apache.maven.plugins</groupId>
+				<artifactId>maven-compiler-plugin</artifactId>
+				<configuration>
+					<annotationProcessorPaths>
+						<path>
+							<groupId>org.projectlombok</groupId>
+							<artifactId>lombok</artifactId>
+							<version>${lombok.version}</version>
+						</path>
+					</annotationProcessorPaths>
+					<!-- 抑制 javac 的 deprecation 警告（如 WebMvcConfig）；Lombok Unsafe 需靠 .mvn/jvm.config 的 -Xlint:-deprecation -->
+					<compilerArgs>
+						<arg>-Xlint:-deprecation</arg>
+					</compilerArgs>
+				</configuration>
+			</plugin>
 			<plugin>
 				<groupId>org.springframework.boot</groupId>
 				<artifactId>spring-boot-maven-plugin</artifactId>

--- a/backend/src/main/java/com/travelPlanWithAccounting/service/entity/TransI18n.java
+++ b/backend/src/main/java/com/travelPlanWithAccounting/service/entity/TransI18n.java
@@ -23,6 +23,10 @@ import lombok.Builder;
 import lombok.Data;
 import lombok.NoArgsConstructor;
 
+/**
+ * 多語系行程區段（起訖明細間）的翻譯／轉乘等資訊。<br>
+ * I18n record for a segment between start/end detail, e.g. translation or transit info.
+ */
 @Entity
 @Valid
 @Data
@@ -32,48 +36,57 @@ import lombok.NoArgsConstructor;
 @AllArgsConstructor
 @Table(name = "trans_i18n")
 public class TransI18n implements Serializable {
-    @Id
-    @GeneratedValue(strategy = GenerationType.UUID) // 使用 GenerationType.UUID 讓JPA自動生成UUID
-    @Column(name = "id", updatable = false, nullable = false, columnDefinition = "UUID")
-    private UUID id;
 
-    @Column(name = "lang_type", nullable = false)
-    private String langType;
+  private static final long serialVersionUID = 1L;
 
-    @Column(name = "start_detail_id", nullable = false)
-    private UUID startDetailId; // 不建立雙向關聯
+  /** 預設轉乘／類型代碼（空字串表示未指定） */
+  private static final String DEFAULT_TRANS_TYPE = "";
 
-    @Column(name = "end_detail_id", nullable = false)
-    private UUID endDetailId; // 不建立雙向關聯
+  // --- 主鍵 ---
+  @Id
+  @GeneratedValue(strategy = GenerationType.UUID)
+  @Column(name = "id", updatable = false, nullable = false, columnDefinition = "UUID")
+  private UUID id;
 
-    @JdbcTypeCode(SqlTypes.JSON)
-    @Column(name = "infos_raw", columnDefinition = "JSONB")
-    // 將 JSON 儲存為 String，您可以使用自定義類型以實現更結構化的訪問
-    private String infosRaw;
+  // --- 業務欄位 ---
+  @Column(name = "lang_type", nullable = false)
+  private String langType;
 
-    @Column(name = "trans_type", length = 50, nullable = false)
-    private String transType = "";
+  @Column(name = "start_detail_id", nullable = false)
+  private UUID startDetailId;
 
-    @Column(name = "trans_time", nullable = false)
-    private LocalTime transTime;
+  @Column(name = "end_detail_id", nullable = false)
+  private UUID endDetailId;
 
-    @Column(name = "summary", columnDefinition = "TEXT")
-    private String summary;
+  @JdbcTypeCode(SqlTypes.JSON)
+  @Column(name = "infos_raw", columnDefinition = "JSONB")
+  private String infosRaw;
 
-    @Column(name = "notes", columnDefinition = "TEXT")
-    private String notes;
+  @Column(name = "trans_type", length = 50, nullable = false)
+  @Builder.Default
+  private String transType = DEFAULT_TRANS_TYPE;
 
-    @Column(name = "created_by")
-    private UUID createdBy;
+  @Column(name = "trans_time", nullable = false)
+  private LocalTime transTime;
 
-    @CreationTimestamp
-    @Column(name = "created_at", nullable = false, updatable = false)
-    private Instant createdAt;
+  @Column(name = "summary", columnDefinition = "TEXT")
+  private String summary;
 
-    @Column(name = "updated_by")
-    private UUID updatedBy;
+  @Column(name = "notes", columnDefinition = "TEXT")
+  private String notes;
 
-    @UpdateTimestamp
-    @Column(name = "updated_at", nullable = false)
-    private Instant updatedAt;
+  // --- 審計欄位 ---
+  @Column(name = "created_by")
+  private UUID createdBy;
+
+  @CreationTimestamp
+  @Column(name = "created_at", nullable = false, updatable = false)
+  private Instant createdAt;
+
+  @Column(name = "updated_by")
+  private UUID updatedBy;
+
+  @UpdateTimestamp
+  @Column(name = "updated_at", nullable = false)
+  private Instant updatedAt;
 }


### PR DESCRIPTION
### Motivation
- Move the backend baseline to JDK 25 and Spring Boot 4 to prepare for an environment and dependency upgrade and make the upgrade plan explicit and auditable. 
- Align build/runtime images and local build scripts with the new Java version so CI/developers use consistent tooling. 
- Update documentation to record the new baseline and provide a concrete review/validation checklist.

### Description
- Bumped Spring Boot parent to `4.0.0` and changed `java.version` to `25` and `springdoc.version` to `3.0.0` in `backend/pom.xml`.
- Switched Docker base images to `eclipse-temurin:25-jre-alpine` in `backend/Dockerfile` and updated build scripts to use `maven:3.9.9-eclipse-temurin-25` in `backend/build.sh` and `backend/build.bat`.
- Updated `backend/README.md` to require `OpenJDK 25` and added a new upgrade plan document at `backend/docs/jdk25-springboot4-upgrade-plan.md` capturing the baseline and review checklist.

### Testing
- Ran `mvn clean install` in `backend`, which failed: Maven could not resolve `org.springframework.boot:spring-boot-starter-parent:4.0.0` due to a `403 Forbidden` when downloading from Maven Central. 
- No further automated tests (Docker image build or container smoke tests) were executed after the parent POM resolution failure.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6986ba96eaec8323bcd681d6b6eff29d)