### PR TITLE
Resolve .backendEnv lookup and add BACKEND_ENV_FILE override for Docker startup

### DIFF
--- a/backend/docker-compose.yml
+++ b/backend/docker-compose.yml
@@ -4,7 +4,7 @@ services:
     ports:
       - "9000:9000"
     env_file:
-      - ../.backendEnv # 與 build.sh 一致
+      - ${BACKEND_ENV_FILE:-../.backendEnv} # 與 build.sh 一致
     networks:
       - app-network
     volumes:
@@ -13,7 +13,7 @@ services:
       # Config
       - ./configs:/application/config
       # Env file for runtime lookup
-      - ../.backendEnv:/application/.backendEnv:ro
+      - ${BACKEND_ENV_FILE:-../.backendEnv}:/application/.backendEnv:ro
 networks:
   app-network:
     driver: bridge

--- a/backend/down.bat
+++ b/backend/down.bat
@@ -1,1 +1,18 @@
-docker compose --env-file ../.backendEnv down
+@echo off
+setlocal
+
+set "ENV_FILE=%BACKEND_ENV_FILE%"
+if "%ENV_FILE%"=="" (
+  if exist "%~dp0..\.backendEnv" set "ENV_FILE=%~dp0..\.backendEnv"
+  if "%ENV_FILE%"=="" if exist "%~dp0.backendEnv" set "ENV_FILE=%~dp0.backendEnv"
+)
+
+if not "%ENV_FILE%"=="" (
+  set "BACKEND_ENV_FILE=%ENV_FILE%"
+  docker compose --env-file "%ENV_FILE%" down
+) else (
+  echo [WARN] 找不到 .backendEnv，將只使用系統環境變數停止。
+  docker compose down
+)
+
+endlocal

--- a/backend/down.sh
+++ b/backend/down.sh
@@ -1,1 +1,21 @@
-docker compose --env-file ../.backendEnv down
+#!/bin/bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+ENV_FILE="${BACKEND_ENV_FILE:-}"
+
+if [ -z "$ENV_FILE" ]; then
+  if [ -f "$SCRIPT_DIR/../.backendEnv" ]; then
+    ENV_FILE="$SCRIPT_DIR/../.backendEnv"
+  elif [ -f "$SCRIPT_DIR/.backendEnv" ]; then
+    ENV_FILE="$SCRIPT_DIR/.backendEnv"
+  fi
+fi
+
+if [ -n "$ENV_FILE" ]; then
+  export BACKEND_ENV_FILE="$ENV_FILE"
+  docker compose --env-file "$ENV_FILE" down
+else
+  echo "[WARN] 找不到 .backendEnv，將只使用系統環境變數停止。"
+  docker compose down
+fi

--- a/backend/src/main/java/com/travelPlanWithAccounting/service/ServiceApplication.java
+++ b/backend/src/main/java/com/travelPlanWithAccounting/service/ServiceApplication.java
@@ -22,9 +22,22 @@ public class ServiceApplication {
 
   /** 負責從環境檔案中載入變數，並優先於系統環境變數 */
   private static void loadEnv() {
-    Path[] possiblePaths = {
-      Paths.get(".backendEnv"), Paths.get("../.backendEnv"), Paths.get("/application/.backendEnv")
-    };
+    String configuredEnvFile = resolveConfiguredEnvFile();
+    Path[] possiblePaths =
+        configuredEnvFile == null
+            ? new Path[] {
+              Paths.get(".backendEnv"),
+              Paths.get("../.backendEnv"),
+              Paths.get("/application/.backendEnv"),
+              Paths.get("/application/config/.backendEnv")
+            }
+            : new Path[] {
+              Paths.get(configuredEnvFile),
+              Paths.get(".backendEnv"),
+              Paths.get("../.backendEnv"),
+              Paths.get("/application/.backendEnv"),
+              Paths.get("/application/config/.backendEnv")
+            };
 
     log.info("當前工作目錄: {}", System.getProperty("user.dir"));
 
@@ -35,6 +48,23 @@ public class ServiceApplication {
     }
 
     log.info("未找到環境變數檔案，將使用系統環境變數。");
+  }
+
+  /**
+   * 從環境變數或系統屬性中取得指定的環境檔案路徑
+   *
+   * @return 指定環境檔案路徑，若未設定則回傳 null
+   */
+  private static String resolveConfiguredEnvFile() {
+    String envFile = System.getProperty("BACKEND_ENV_FILE");
+    if (envFile != null && !envFile.isBlank()) {
+      return envFile.trim();
+    }
+    envFile = System.getenv("BACKEND_ENV_FILE");
+    if (envFile != null && !envFile.isBlank()) {
+      return envFile.trim();
+    }
+    return null;
   }
 
   /**

--- a/backend/up.bat
+++ b/backend/up.bat
@@ -1,1 +1,18 @@
-docker compose --env-file ../.backendEnv up -d --remove-orphans --force-recreate
+@echo off
+setlocal
+
+set "ENV_FILE=%BACKEND_ENV_FILE%"
+if "%ENV_FILE%"=="" (
+  if exist "%~dp0..\.backendEnv" set "ENV_FILE=%~dp0..\.backendEnv"
+  if "%ENV_FILE%"=="" if exist "%~dp0.backendEnv" set "ENV_FILE=%~dp0.backendEnv"
+)
+
+if not "%ENV_FILE%"=="" (
+  set "BACKEND_ENV_FILE=%ENV_FILE%"
+  docker compose --env-file "%ENV_FILE%" up -d --remove-orphans --force-recreate
+) else (
+  echo [WARN] 找不到 .backendEnv，將只使用系統環境變數啟動。
+  docker compose up -d --remove-orphans --force-recreate
+)
+
+endlocal

--- a/backend/up.sh
+++ b/backend/up.sh
@@ -1,1 +1,21 @@
-docker compose --env-file ../.backendEnv up -d --remove-orphans --force-recreate
+#!/bin/bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+ENV_FILE="${BACKEND_ENV_FILE:-}"
+
+if [ -z "$ENV_FILE" ]; then
+  if [ -f "$SCRIPT_DIR/../.backendEnv" ]; then
+    ENV_FILE="$SCRIPT_DIR/../.backendEnv"
+  elif [ -f "$SCRIPT_DIR/.backendEnv" ]; then
+    ENV_FILE="$SCRIPT_DIR/.backendEnv"
+  fi
+fi
+
+if [ -n "$ENV_FILE" ]; then
+  export BACKEND_ENV_FILE="$ENV_FILE"
+  docker compose --env-file "$ENV_FILE" up -d --remove-orphans --force-recreate
+else
+  echo "[WARN] 找不到 .backendEnv，將只使用系統環境變數啟動。"
+  docker compose up -d --remove-orphans --force-recreate
+fi


### PR DESCRIPTION
### Motivation
- The backend container could not find the `.backendEnv` file at runtime when started from Docker Desktop, causing the app to fallback to system envs; the startup and orchestration scripts need a consistent, overrideable way to locate the env file across platforms. 

### Description
- Add support for a `BACKEND_ENV_FILE` override (read from `System.getProperty` or `System.getenv`) and an extra fallback path `/application/config/.backendEnv` in `ServiceApplication.loadEnv()` so the JVM startup will attempt a configurable sequence of locations. 
- Change `backend/docker-compose.yml` to use `${BACKEND_ENV_FILE:-../.backendEnv}` for `env_file` and the runtime volume mapping so Docker Compose can use an externally-provided env-file path. 
- Replace the simple `docker compose --env-file ../.backendEnv` lines with robust platform scripts in `backend/up.sh`, `backend/down.sh`, `backend/up.bat`, and `backend/down.bat` that resolve `BACKEND_ENV_FILE` from an existing `.backendEnv` in the repo tree, export it for compose, and fall back to starting with system envs while emitting a warning. 

### Testing
- Attempted `./mvnw clean install` in `backend` but the wrapper execution failed with `Permission denied` (no change applied to wrapper permissions in this PR). 
- Ran `mvn clean install` which failed due to remote artifact resolution (`org.springframework.boot:spring-boot-starter-parent:4.0.2`) returning HTTP 403 from Maven Central, so full compile/test could not complete. 
- Confirmed file edits and script behavior via local shell checks (`nl`/`cat`/`sed` outputs) and committed changes successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698720a7705483238ee0656f46f29dca)