### PR TITLE
Support BACKEND_ENV_FILE override and improve env-file discovery for backend

### DIFF
--- a/backend/docker-compose.yml
+++ b/backend/docker-compose.yml
@@ -4,7 +4,7 @@ services:
     ports:
       - "9000:9000"
     env_file:
-      - ../.backendEnv # 與 build.sh 一致
+      - ${BACKEND_ENV_FILE:-../.backendEnv} # 與 build.sh 一致
     networks:
       - app-network
     volumes:
@@ -13,7 +13,7 @@ services:
       # Config
       - ./configs:/application/config
       # Env file for runtime lookup
-      - ../.backendEnv:/application/.backendEnv:ro
+      - ${BACKEND_ENV_FILE:-../.backendEnv}:/application/.backendEnv:ro
 networks:
   app-network:
     driver: bridge

--- a/backend/down.bat
+++ b/backend/down.bat
@@ -1,1 +1,18 @@
-docker compose --env-file ../.backendEnv down
+@echo off
+setlocal
+
+set "SCRIPT_DIR=%~dp0"
+set "DEFAULT_ENV_FILE=%SCRIPT_DIR%..\.backendEnv"
+set "ALT_ENV_FILE=%SCRIPT_DIR%.backendEnv"
+
+if exist "%DEFAULT_ENV_FILE%" (
+  set "ENV_FILE=%DEFAULT_ENV_FILE%"
+) else if exist "%ALT_ENV_FILE%" (
+  set "ENV_FILE=%ALT_ENV_FILE%"
+) else (
+  set "ENV_FILE=%DEFAULT_ENV_FILE%"
+)
+
+set "BACKEND_ENV_FILE=%ENV_FILE%"
+docker compose --env-file "%ENV_FILE%" down
+endlocal

--- a/backend/down.sh
+++ b/backend/down.sh
@@ -1,1 +1,18 @@
-docker compose --env-file ../.backendEnv down
+#!/bin/bash
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+DEFAULT_ENV_FILE="$SCRIPT_DIR/../.backendEnv"
+ALT_ENV_FILE="$SCRIPT_DIR/.backendEnv"
+
+if [ -f "$DEFAULT_ENV_FILE" ]; then
+  ENV_FILE="$DEFAULT_ENV_FILE"
+elif [ -f "$ALT_ENV_FILE" ]; then
+  ENV_FILE="$ALT_ENV_FILE"
+else
+  ENV_FILE="$DEFAULT_ENV_FILE"
+fi
+
+export BACKEND_ENV_FILE="$ENV_FILE"
+docker compose --env-file "$ENV_FILE" down

--- a/backend/src/main/java/com/travelPlanWithAccounting/service/ServiceApplication.java
+++ b/backend/src/main/java/com/travelPlanWithAccounting/service/ServiceApplication.java
@@ -22,11 +22,21 @@ public class ServiceApplication {
 
   /** 負責從環境檔案中載入變數，並優先於系統環境變數 */
   private static void loadEnv() {
-    Path[] possiblePaths = {
-      Paths.get(".backendEnv"), Paths.get("../.backendEnv"), Paths.get("/application/.backendEnv")
-    };
+    String envFileOverride = System.getenv("BACKEND_ENV_FILE");
+    Path[] possiblePaths =
+        envFileOverride == null || envFileOverride.isBlank()
+            ? new Path[] {
+              Paths.get(".backendEnv"),
+              Paths.get("../.backendEnv"),
+              Paths.get("/application/.backendEnv"),
+              Paths.get("/application/config/.backendEnv")
+            }
+            : new Path[] {Paths.get(envFileOverride)};
 
     log.info("當前工作目錄: {}", System.getProperty("user.dir"));
+    if (envFileOverride != null && !envFileOverride.isBlank()) {
+      log.info("使用 BACKEND_ENV_FILE 指定路徑: {}", envFileOverride);
+    }
 
     for (Path envPath : possiblePaths) {
       if (tryLoadEnvFile(envPath)) {

--- a/backend/up.bat
+++ b/backend/up.bat
@@ -1,1 +1,18 @@
-docker compose --env-file ../.backendEnv up -d --remove-orphans --force-recreate
+@echo off
+setlocal
+
+set "SCRIPT_DIR=%~dp0"
+set "DEFAULT_ENV_FILE=%SCRIPT_DIR%..\.backendEnv"
+set "ALT_ENV_FILE=%SCRIPT_DIR%.backendEnv"
+
+if exist "%DEFAULT_ENV_FILE%" (
+  set "ENV_FILE=%DEFAULT_ENV_FILE%"
+) else if exist "%ALT_ENV_FILE%" (
+  set "ENV_FILE=%ALT_ENV_FILE%"
+) else (
+  set "ENV_FILE=%DEFAULT_ENV_FILE%"
+)
+
+set "BACKEND_ENV_FILE=%ENV_FILE%"
+docker compose --env-file "%ENV_FILE%" up -d --remove-orphans --force-recreate
+endlocal

--- a/backend/up.sh
+++ b/backend/up.sh
@@ -1,1 +1,18 @@
-docker compose --env-file ../.backendEnv up -d --remove-orphans --force-recreate
+#!/bin/bash
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+DEFAULT_ENV_FILE="$SCRIPT_DIR/../.backendEnv"
+ALT_ENV_FILE="$SCRIPT_DIR/.backendEnv"
+
+if [ -f "$DEFAULT_ENV_FILE" ]; then
+  ENV_FILE="$DEFAULT_ENV_FILE"
+elif [ -f "$ALT_ENV_FILE" ]; then
+  ENV_FILE="$ALT_ENV_FILE"
+else
+  ENV_FILE="$DEFAULT_ENV_FILE"
+fi
+
+export BACKEND_ENV_FILE="$ENV_FILE"
+docker compose --env-file "$ENV_FILE" up -d --remove-orphans --force-recreate


### PR DESCRIPTION
### Motivation
- Docker Desktop runs sometimes place the env file in different paths and the app could not find `./.backendEnv`, so startup fell back to system env vars unexpectedly.
- Compose and helper scripts referenced a hardcoded `../.backendEnv`, which made runtime mounts and runtime lookup brittle in alternate layouts (container image uses `/application`).

### Description
- Add support for `BACKEND_ENV_FILE` override and an extra lookup path `/application/config/.backendEnv` in `ServiceApplication.loadEnv()` so the JVM will load the correct env file when present and log the chosen override path. 
- Update `backend/docker-compose.yml` to use `${BACKEND_ENV_FILE:-../.backendEnv}` for `env_file` and for the runtime mount so compose honors the resolved env file. 
- Replace simple compose commands with helper scripts that detect the env file and export `BACKEND_ENV_FILE` consistently by updating `backend/up.sh`, `backend/down.sh`, `backend/up.bat`, and `backend/down.bat`. 
- Ensure logs indicate the working directory and when an explicit `BACKEND_ENV_FILE` is used for easier debugging. 

### Testing
- Ran `./mvnw clean install` which failed due to missing wrapper files and permission issues (wrapper not usable in this environment). 
- Ran `mvn clean install` in `backend/` which failed with a Maven resolution error (HTTP 403 when fetching `org.springframework.boot:spring-boot-starter-parent:4.0.2` from Maven Central).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698720a7705483238ee0656f46f29dca)