### PR TITLE
docs/pom: update Codex Web internet-access runbook and add Maven repositories for JDK25 upgrade

### DIFF
--- a/backend/docs/prd/jdk25-upgrade-plan-codex.md
+++ b/backend/docs/prd/jdk25-upgrade-plan-codex.md
@@ -1,130 +1,142 @@
-# JDK 25 Upgrade Plan (Codex-Execution Locked v2)
+# JDK 25 升級計畫（Codex Web 聯網版 v3）
 
-> 目的：提供 **Codex 可穩定執行、可追溯、可回滾** 的 JDK 21 → JDK 25 升級 PRD。
->
-> 原則：一次到位（single pass）、失敗即停止（No-Go）、結論必須有證據。
->
-> 此檔案為增補文件，不取代 `jdk25-upgrade-plan.md`。
+> 更新日期：2026-04-03  
+> 目的：修正「Codex 網頁模式執行時 agent phase 聯網被禁止，導致 Maven 依賴無法下載」問題，並讓升級流程可直接驗證 `mvn clean install` 與 `mvn test`。
 
 ---
 
-## 1) Scope / Non-Goals
+## 0. 這版修正了什麼
+
+根據 OpenAI 官方文件 **Agent internet access – Codex web**：
+
+- Codex 預設會在 **agent phase 封鎖網路**。
+- 只有 setup scripts 預設可上網，agent 本體仍可能被擋。
+- 要在 Web 環境中手動開啟 agent internet access，並設定 allowlist 與 HTTP methods。
+
+因此本版將流程改成：
+
+1. 先在 Codex Web Environment 開啟 **Agent internet access = On**。
+2. Domain allowlist 使用 **Common dependencies**，再補上 Maven/JDK 升級必需網域。
+3. HTTP methods 限制為 `GET`, `HEAD`, `OPTIONS`（官方建議最小權限）。
+4. 用固定 Gate 逐步驗證，要求 `mvn clean install` 與 `mvn test` 都必須可執行。
+
+---
+
+## 1. Scope / Non-Goals
 
 ### Scope（本次一定做）
-- 升級執行與建置 JDK：`21 -> 25`
-- 維持 Maven `3.9.14`（除非證據顯示 Maven 本身為阻塞點）
-- 驗證：compile、test、package、（可選）startup
-- 產出單一決策：`GO` 或 `NO-GO`
+- JDK：`21 -> 25`
+- Maven：維持既有版本（目前專案是 3.9.x）
+- 驗證：`mvn clean install`、`mvn test`
+- 輸出單一決策：`GO` 或 `NO-GO`
 
 ### Non-Goals（本次不做）
-- 大量依賴批次升版
+- 一次升級多個依賴版本
 - 無關功能重構
-- 先改 Docker 再驗證 local（流程相反）
-- 模糊判定（例如「看起來差不多可行」）
+- 不可追溯的手動臨時修補
 
 ---
 
-## 2) Codex Execution Contract（避免跑掉）
+## 2. Codex Web 必要設定（先做，不可跳過）
 
-1. **Single-variable first**：先只改 JDK 與 `<java.version>`。
-2. **Fail-fast**：任一 Gate 失敗即停止，不繼續「順手修更多」。
-3. **Evidence-based**：每個結論都需對應 command + log artifact。
-4. **Deterministic commands**：所有命令可直接複製執行。
-5. **No hidden context**：必要 profile / env 都寫進命令，不靠人腦記憶。
-6. **One-primary-root-cause**：每次 NO-GO 僅判定一個主要根因。
+> 位置：Codex Web → Environment → Internet Access
+
+### 2.1 Agent internet access
+- 設為：`On`
+
+### 2.2 Domain allowlist
+- Preset：`Common dependencies`
+- 另外追加（建議精準補齊 Maven/JDK 下載路徑）：
+  - `repo.maven.apache.org`
+  - `repo1.maven.org`
+  - `repo.spring.io`
+  - `start.spring.io`
+  - `api.adoptium.net`
+  - `download.oracle.com`
+  - `github.com`
+  - `raw.githubusercontent.com`
+
+> 說明：
+> - `Common dependencies` 已含 `apache.org`, `maven.org`, `spring.io`, `github.com`, `java.com`, `java.net`, `oracle.com` 等常見網域。
+> - 但實務上建議補「實際下載 host」如 `repo.maven.apache.org`，避免被精準網域比對擋下。
+
+### 2.3 Allowed HTTP methods
+- 只允許：`GET`, `HEAD`, `OPTIONS`
+- 禁止：`POST`, `PUT`, `PATCH`, `DELETE` 等寫入型方法
 
 ---
 
-## 3) Fixed Inputs
+## 3. 與本專案直接相關的網路需求（pom.xml + 升級腳本）
 
-- Project path: `backend/`
-- Baseline JDK: `21`
-- Target JDK: `25`
-- Build tool: `Maven 3.9.14`
-- POM Java property (current): `<java.version>21</java.version>`
+本專案 `pom.xml` 與升級流程需要可下載：
+
+- Maven parent POM（Spring Boot Parent）
+- Maven plugins（compiler/surefire/spring-boot plugin 等）
+- 專案依賴（Spring/JJWT/PostgreSQL/OpenAPI 等）
+
+關鍵來源站：
+- `repo.maven.apache.org`（Maven Central）
+- `repo.spring.io`（Spring artifacts／必要時）
+
+若這些網域未放行，常見失敗會是：
+- `Non-resolvable parent POM`
+- `Could not transfer artifact ... status code: 403`
 
 ---
 
-## 4) Preflight (Mandatory)
+## 4. 執行契約（Execution Contract）
 
-> 任一步驟不通過，立即停止。
+1. **Single-variable first**：先只切 JDK 與 `java.version`。
+2. **Fail-fast**：任一 Gate 失敗立即停止。
+3. **Evidence-based**：每一步都要有可追溯輸出。
+4. **Deterministic commands**：命令可直接複製執行。
 
-From `backend/`:
+---
+
+## 5. Gate A（JDK 21 Baseline）
+
+在 `backend/` 目錄執行：
 
 ```bash
 set -euo pipefail
-
-# 0) Git cleanliness（避免未提交變更污染證據）
-git status --porcelain
-
-# 1) Tool availability
-command -v java
-command -v mvn
-
-# 2) Runtime identity
-java -version
-mvn -version
-
-# 3) Effective Java property (from Maven model)
-mvn -q help:evaluate -Dexpression=java.version -DforceStdout
-```
-
-Preflight Pass Criteria:
-- `java` / `mvn` 都可用
-- `mvn -version` 顯示的 Java 與預期一致
-- `help:evaluate` 可穩定回傳 `java.version`
-
----
-
-## 5) Gate Model
-
-### Gate A — Baseline must be GREEN on JDK 21
-
-```bash
 mkdir -p .upgrade
+
 java -version | tee .upgrade/a-java-version.txt
 mvn -version | tee .upgrade/a-mvn-version.txt
 mvn -q help:evaluate -Dexpression=java.version -DforceStdout | tee .upgrade/a-java-property.txt
-mvn -q -DskipTests dependency:tree > .upgrade/a-deps.txt
+
 mvn clean install | tee .upgrade/a-clean-install.txt
 mvn test | tee .upgrade/a-test.txt
 ```
 
-Gate A pass:
+Gate A 通過條件：
 - 所有命令 exit code = 0
-- `.upgrade/a-*` 證據存在
-
-Gate A fail:
-- **STOP**（不是升級回歸，是 baseline 不穩）
+- `.upgrade/a-*` 證據檔存在
 
 ---
 
-### Gate B — Switch to JDK 25 + minimal source change
+## 6. Gate B（切換 JDK 25）
 
 1. 外部切換 shell JDK 至 25
-2. 確認：
+2. 驗證：
 
 ```bash
 java -version | tee .upgrade/b-java-version.txt
 mvn -version | tee .upgrade/b-mvn-version.txt
 ```
 
-3. 僅允許以下變更：
-- `pom.xml`: `<java.version>25</java.version>`
+3. 僅允許必要變更：
+- `pom.xml`：`<java.version>25</java.version>`
 
-4. 確認 Maven model：
+4. 驗證 Maven model：
 
 ```bash
 mvn -q help:evaluate -Dexpression=java.version -DforceStdout | tee .upgrade/b-java-property.txt
 ```
 
-Gate B pass:
-- `java -version` 為 25
-- `java.version` 為 25
-
 ---
 
-### Gate C — Validate on JDK 25
+## 7. Gate C（JDK 25 驗證）
 
 ```bash
 mvn -U clean compile | tee .upgrade/c-compile.txt
@@ -132,61 +144,35 @@ mvn test | tee .upgrade/c-test.txt
 mvn clean install | tee .upgrade/c-clean-install.txt
 ```
 
-Optional（環境完整時才執行）:
-
-```bash
-mvn spring-boot:run | tee .upgrade/c-run.txt
-```
-
-Gate C pass:
+Gate C 通過條件：
 - compile/test/install 全綠
-- optional run（若執行）可正常啟動
-
-Gate C fail:
-- **NO-GO + rollback**（見 Section 7）
 
 ---
 
-## 6) Failure Taxonomy（真實原因）
+## 8. 失敗分類（NO-GO Root Cause）
 
-失敗必須歸類到 **單一主因**：
+單一主因分類：
+- `ENVIRONMENT`：JDK/PATH 錯誤
+- `NETWORK_POLICY`：Codex environment 沒放行對應網域/方法
+- `COMPILER`：JDK 25 編譯不相容
+- `TEST`：JDK 25 行為差異
+- `DEPENDENCY`：依賴本身不相容
 
-1. `ENVIRONMENT`
-   - `JAVA_HOME/PATH` 指向錯誤
-   - `mvn -version` 顯示 Java 與預期不一致
-
-2. `COMPILER`
-   - `release/source/target` 或 annotation processor 相容性錯誤
-
-3. `TEST`
-   - 單元/整合測試在 JDK 25 出現行為差異
-
-4. `RUNTIME_BOOT`
-   - Spring context 啟動失敗、模組/反射限制
-
-5. `DEPENDENCY`
-   - 第三方套件與 JDK 25 不相容
-
-### First-error extraction（避免誤判）
+First error 擷取：
 
 ```bash
-# 擷取第一個 ERROR/FATAL 線索（示例）
-rg -n "ERROR|FATAL|BUILD FAILURE|COMPILATION ERROR" .upgrade/c-*.txt | head -n 20
+rg -n "ERROR|FATAL|BUILD FAILURE|COMPILATION ERROR|Non-resolvable|Could not transfer" .upgrade/*.txt | head -n 30
 ```
-
-規則：
-- 以「第一個可重現失敗點」當主因
-- 不以連鎖錯誤（downstream noise）當根因
 
 ---
 
-## 7) NO-GO Rollback Procedure
+## 9. Rollback
 
-當 Gate C fail：
+若 Gate C 失敗：
 
-1. 還原 `pom.xml` 的 `<java.version>` 回 `21`
-2. shell 切回 JDK 21
-3. 重新確認 baseline：
+1. 還原 `pom.xml` 的 `<java.version>` 至 `21`
+2. 切回 JDK 21
+3. 重跑：
 
 ```bash
 java -version
@@ -194,55 +180,9 @@ mvn -version
 mvn clean install
 ```
 
-4. 補齊 NO-GO 報告（見 Section 10）並停止
-
 ---
 
-## 8) Minimal Remediation Policy
-
-只有在證據支持時，才允許最小修復。
-
-允許：
-- 因編譯錯誤而補 `maven-compiler-plugin` 的最小配置
-- 因明確不相容而升級「單一」依賴
-
-禁止：
-- 一次升多個依賴
-- 將非根因議題混入本輪
-
----
-
-## 9) Codex Runbook (Copy/Paste)
-
-From `backend/`:
-
-```bash
-set -euo pipefail
-mkdir -p .upgrade
-
-# ---- Gate A: Baseline on JDK 21 ----
-java -version | tee .upgrade/a-java-version.txt
-mvn -version | tee .upgrade/a-mvn-version.txt
-mvn -q help:evaluate -Dexpression=java.version -DforceStdout | tee .upgrade/a-java-property.txt
-mvn -q -DskipTests dependency:tree > .upgrade/a-deps.txt
-mvn clean install | tee .upgrade/a-clean-install.txt
-mvn test | tee .upgrade/a-test.txt
-
-# ---- Gate B: switch to JDK 25 externally ----
-java -version | tee .upgrade/b-java-version.txt
-mvn -version | tee .upgrade/b-mvn-version.txt
-# edit pom.xml: <java.version>25</java.version>
-mvn -q help:evaluate -Dexpression=java.version -DforceStdout | tee .upgrade/b-java-property.txt
-
-# ---- Gate C: validate on JDK 25 ----
-mvn -U clean compile | tee .upgrade/c-compile.txt
-mvn test | tee .upgrade/c-test.txt
-mvn clean install | tee .upgrade/c-clean-install.txt
-```
-
----
-
-## 10) GO/NO-GO Report Template
+## 10. GO/NO-GO Report Template
 
 ```md
 # JDK 25 Upgrade Result
@@ -255,36 +195,38 @@ mvn clean install | tee .upgrade/c-clean-install.txt
 - mvn -version: ...
 - java.version (maven model): ...
 
+## Internet Access Snapshot (Codex Web)
+- Agent internet access: On/Off
+- Domain preset: None | Common dependencies | All
+- Added domains: ...
+- Allowed methods: ...
+
 ## Evidence
-- Commands:
-  - ...
-- Artifacts:
-  - .upgrade/a-...
-  - .upgrade/b-...
-  - .upgrade/c-...
+- Commands: ...
+- Artifacts: .upgrade/a-..., .upgrade/b-..., .upgrade/c-...
 
 ## If NO-GO: Root Cause
-- Category: ENVIRONMENT | COMPILER | TEST | RUNTIME_BOOT | DEPENDENCY
+- Category: ENVIRONMENT | NETWORK_POLICY | COMPILER | TEST | DEPENDENCY
 - First failing command: ...
 - First deterministic error line: ...
-- Why this is primary cause: ...
 - Minimal fix proposal: ...
-- Risk: low | medium | high
 
 ## Rollback Verification
 - pom.xml java.version restored to 21: yes/no
 - JDK switched back to 21: yes/no
-- `mvn clean install` on JDK21: pass/fail
+- mvn clean install on JDK21: pass/fail
 ```
 
 ---
 
-## 11) Acceptance Criteria
+## 11. Acceptance Criteria
 
-Only `GO` when all true:
+只有同時滿足以下條件才可判定 `GO`：
+
+- Codex Web 已啟用 Agent internet access（且最小權限）
 - Gate A/B/C 全通過
-- `.upgrade/` 證據完整
-- 無隱含人工步驟
-- 失敗時有完整 NO-GO 報告
+- `mvn clean install` 成功
+- `mvn test` 成功
+- `.upgrade/` 證據完整可追溯
 
-若任一未滿足，結果一律 `NO-GO`。
+任一不滿足即 `NO-GO`。

--- a/backend/pom.xml
+++ b/backend/pom.xml
@@ -31,6 +31,33 @@
 		<java.version>21</java.version>
 		<springdoc.version>3.0.1</springdoc.version>
 	</properties>
+
+	<repositories>
+		<repository>
+			<id>central</id>
+			<name>Maven Central</name>
+			<url>https://repo.maven.apache.org/maven2</url>
+		</repository>
+		<repository>
+			<id>spring-releases</id>
+			<name>Spring Releases</name>
+			<url>https://repo.spring.io/release</url>
+		</repository>
+	</repositories>
+
+	<pluginRepositories>
+		<pluginRepository>
+			<id>central-plugins</id>
+			<name>Maven Central Plugins</name>
+			<url>https://repo.maven.apache.org/maven2</url>
+		</pluginRepository>
+		<pluginRepository>
+			<id>spring-plugins</id>
+			<name>Spring Plugin Repository</name>
+			<url>https://repo.spring.io/release</url>
+		</pluginRepository>
+	</pluginRepositories>
+
 	<dependencies>
 		<dependency>
 			<groupId>org.springframework.boot</groupId>


### PR DESCRIPTION
### Motivation
- Make the JDK 21→25 upgrade runbook runnable in Codex Web by documenting and fixing the agent-phase network access constraints that block Maven artifact downloads.  
- Ensure the project explicitly declares the repositories needed so artifact resolution is visible and auditable in environments with restricted network policies.

### Description
- Rewrote `backend/docs/prd/jdk25-upgrade-plan-codex.md` into a Codex Web–focused v3 runbook that requires turning Agent internet access ON, using the `Common dependencies` preset, and adding Maven/JDK hosts plus limiting HTTP methods to `GET/HEAD/OPTIONS`.  
- Added an explicit `NETWORK_POLICY` failure category and Internet Access Snapshot fields to the GO/NO-GO report template.  
- Updated `backend/pom.xml` to declare `repositories` and `pluginRepositories` for `https://repo.maven.apache.org/maven2` and `https://repo.spring.io/release` to make remote artifact sources explicit.  

### Testing
- Ran `cd backend && mvn test`; the build attempted to download `org.springframework.boot:spring-boot-starter-parent:4.0.4` and failed with a `Non-resolvable parent POM` caused by HTTP 403 from `https://repo.maven.apache.org/maven2`, so the test run failed.  
- Ran `cd backend && mvn clean install`; the install also failed with the same 403 artifact-download error.  
- Both failures match the documented Codex Web network-policy issue addressed by the updated runbook and indicate that the commands should succeed once Agent internet access is enabled and the allowlist includes the listed Maven/JDK hosts.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69cfa7601d7083238030f54267e6c529)