### PR TITLE
chore(backend): upgrade backend to JDK 25 target

### DIFF
--- a/backend/pom.xml
+++ b/backend/pom.xml
@@ -28,7 +28,8 @@
 		<url />
 	</scm>
 	<properties>
-		<java.version>21</java.version>
+		<java.version>25</java.version>
+		<maven.compiler.proc>full</maven.compiler.proc>
 		<springdoc.version>3.0.1</springdoc.version>
 	</properties>
 


### PR DESCRIPTION
### Motivation
- 將後端建置目標從 JDK `21` 升級到 JDK `25`，依 `jdk25-upgrade-plan-codex.md` 驗證流程以檢查相容性並取得可追溯的證據。 
- 在保持最小變更原則下，解決 JDK 25 下 Lombok/annotation-processing 可能導致的編譯符號遺失問題。 

### Description
- 修改 `backend/pom.xml`，將 `<java.version>` 從 `21` 改為 `25` 並新增 `<maven.compiler.proc>full</maven.compiler.proc>` 屬性以確保 annotation processing 在 JDK 25 下正常運作。 
- 僅變更 `backend/pom.xml` 一個檔案，並保留使用系統 `mvn`（因 `.mvn/wrapper/maven-wrapper.properties` 不完整）的回退行為與專案內固定 local repo `backend/.m2/repository`。 
- 驗證過程產生之證據檔放於 `backend/.upgrade/`，流程遵循 Setup / Preflight / Gate0 / GateA / GateB / GateC 分段檢查。 

### Testing
- 網路與預熱：執行 `curl` 對 `https://repo.maven.apache.org/maven2/` 與 `https://repo.spring.io/release/` 回傳 `200`，並執行 `mvn -B -Dmaven.repo.local="$PWD/.m2/repository" dependency:go-offline` 與 `dependency:resolve-plugins`，皆成功。 
- JDK21 baseline：在 JDK21 環境執行 `mvn -B test` 與 `mvn -B clean install`，兩者皆成功，通過 Gate A。 
- JDK25 驗證：切換至 JDK25 後執行 `mvn -B help:effective-pom`、`mvn -B -Dmaven.repo.local="$PWD/.m2/repository" clean compile`、`mvn -B test` 與 `mvn -B clean install`，在加入 `maven.compiler.proc=full` 後，compile/test/install 均成功，Gate B/C 通過。 
- 測試摘要：最終在 JDK25 的 `clean compile`、`test`、`clean install` 都成功，但目前測試套件回報 `Tests run: 0`，建議補充實際 unit/integration tests 提升回歸信心。

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69d0e05c548c832389f8a53ede6fd852)