### PR TITLE
chore(backend): 升級後端 Docker/Build 映像至 JDK 25 與 Maven 3.9.13

### DIFF
--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -1,11 +1,11 @@
 # 構建階段
-FROM eclipse-temurin:21-jre-alpine AS builder
+FROM eclipse-temurin:25-jre-alpine AS builder
 WORKDIR /application/jar
 COPY target/*.jar application.jar
 RUN java -Djarmode=layertools -jar application.jar extract
 
 # 運行階段
-FROM eclipse-temurin:21-jre-alpine
+FROM eclipse-temurin:25-jre-alpine
 RUN apk add --no-cache bash
 WORKDIR /application
 # 複製分層構建的結果

--- a/backend/README.md
+++ b/backend/README.md
@@ -2,9 +2,9 @@
 
 ## 環境需求
 
-- **OpenJDK 21.0.6 LTS**  
-  [下載連結](https://learn.microsoft.com/en-us/java/openjdk/download#openjdk-21)
-- **Maven 3.9.9**  
+- **OpenJDK 25**  
+  [下載連結](https://learn.microsoft.com/en-us/java/openjdk/download)
+- **Maven 3.9.13**  
   [下載連結](https://maven.apache.org/download.cgi)
 
 ---

--- a/backend/build.bat
+++ b/backend/build.bat
@@ -40,12 +40,12 @@ REM Convert Windows path to Docker path format
 set "HOST_DIR_DOCKER=%HOST_DIR:\=/%"
 
 REM Use Docker to extract artifactId
-for /f "tokens=*" %%a in ('docker run --rm -v "%HOST_DIR_DOCKER%:/app" -w "%CONTAINER_WORKDIR%" maven:3.9.9-eclipse-temurin-21 mvn help:evaluate -Dexpression^=project.artifactId -q -DforceStdout') do (
+for /f "tokens=*" %%a in ('docker run --rm -v "%HOST_DIR_DOCKER%:/app" -w "%CONTAINER_WORKDIR%" maven:3.9.13-eclipse-temurin-25 mvn help:evaluate -Dexpression^=project.artifactId -q -DforceStdout') do (
     set "APP_NAME=%%a"
 )
 
 REM Use Docker to extract version
-for /f "tokens=*" %%a in ('docker run --rm -v "%HOST_DIR_DOCKER%:/app" -w "%CONTAINER_WORKDIR%" maven:3.9.9-eclipse-temurin-21 mvn help:evaluate -Dexpression^=project.version -q -DforceStdout') do (
+for /f "tokens=*" %%a in ('docker run --rm -v "%HOST_DIR_DOCKER%:/app" -w "%CONTAINER_WORKDIR%" maven:3.9.13-eclipse-temurin-25 mvn help:evaluate -Dexpression^=project.version -q -DforceStdout') do (
     set "VERSION=%%a"
 )
 
@@ -65,7 +65,7 @@ set "IMAGE_NAME=!APP_NAME!:!VERSION!"
 echo [SUCCESS] Project info: name=!APP_NAME!, version=!VERSION!, JAR=!JAR_NAME!
 
 echo [INFO] Building Maven project...
-docker run --rm -v "%HOST_DIR_DOCKER%:/app" -w "%CONTAINER_WORKDIR%" maven:3.9.9-eclipse-temurin-21 mvn clean package -DskipTests
+docker run --rm -v "%HOST_DIR_DOCKER%:/app" -w "%CONTAINER_WORKDIR%" maven:3.9.13-eclipse-temurin-25 mvn clean package -DskipTests
 
 if %ERRORLEVEL% NEQ 0 (
     echo [ERROR] Maven build failed

--- a/backend/build.sh
+++ b/backend/build.sh
@@ -1,12 +1,12 @@
 #!/bin/bash
 
 # 腳本名稱: build.sh
-# 用途: 使用 maven:3.9.9-eclipse-temurin-21 容器打包 Maven 專案，構建 Docker 鏡像，支援 monorepo 結構查找 pom.xml 和 Dockerfile，動態查找 .backendEnv
+# 用途: 使用 maven:3.9.13-eclipse-temurin-25 容器打包 Maven 專案，構建 Docker 鏡像，支援 monorepo 結構查找 pom.xml 和 Dockerfile，動態查找 .backendEnv
 # 使用方式: chmod +x build.sh && ./build.sh
 
 # 配置參數
 DOCKERFILE="Dockerfile"
-MAVEN_IMAGE="maven:3.9.9-eclipse-temurin-21"
+MAVEN_IMAGE="maven:3.9.13-eclipse-temurin-25"
 
 # 顏色輸出函數
 RED='\033[0;31m'


### PR DESCRIPTION
### Motivation
- 將專案的 Docker 執行環境與本地 build toolchain 與已升級的 JDK/Maven 對齊以避免執行時不一致問題。 
- 僅做最小必要的工具鏈與文件更新，不改動應用程式業務邏輯或 API。 

### Description
- 將 `backend/Dockerfile` 的 builder 與 runtime base image 從 `eclipse-temurin:21-jre-alpine` 換成 `eclipse-temurin:25-jre-alpine`。 
- 將 build 腳本中使用的 Docker 化 Maven 映像從 `maven:3.9.9-eclipse-temurin-21` 升級為 `maven:3.9.13-eclipse-temurin-25`，變更包含 `backend/build.sh` 與 `backend/build.bat`。 
- 更新 `backend/README.md` 中的環境需求說明為 `OpenJDK 25` 與 `Maven 3.9.13`，其餘程式碼未修改。 

### Testing
- 執行了 `bash -n backend/build.sh` 進行語法檢查，結果為通過。 
- 嘗試檢查 `docker --version` 以驗證 Docker 可用性，但在此執行環境中 `docker` 指令不存在因此無法在本地完成映像構建與容器啟動驗證。 
- 注意：由於 CI/本地環境未在此處跑 `docker build` 與 `sh backend/build.sh` 完整流程，建議在有 Docker 的環境或 CI 上執行 `cd backend && sh build.sh`（或 Windows 上的 `.uild.bat`）以完成最終驗證。

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69d0eba61b488323bfd24f196636cd84)