### PR TITLE
chore: 將 backend Docker 與 build image 升級到 JDK 25 與 Maven 3.9.14

### DIFF
--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -1,11 +1,11 @@
 # 構建階段
-FROM eclipse-temurin:21-jre-alpine AS builder
+FROM eclipse-temurin:25-jre-alpine AS builder
 WORKDIR /application/jar
 COPY target/*.jar application.jar
 RUN java -Djarmode=layertools -jar application.jar extract
 
 # 運行階段
-FROM eclipse-temurin:21-jre-alpine
+FROM eclipse-temurin:25-jre-alpine
 RUN apk add --no-cache bash
 WORKDIR /application
 # 複製分層構建的結果

--- a/backend/README.md
+++ b/backend/README.md
@@ -2,9 +2,9 @@
 
 ## 環境需求
 
-- **OpenJDK 21.0.6 LTS**  
-  [下載連結](https://learn.microsoft.com/en-us/java/openjdk/download#openjdk-21)
-- **Maven 3.9.9**  
+- **OpenJDK 25 LTS**  
+  [下載連結](https://learn.microsoft.com/en-us/java/openjdk/download#openjdk-25)
+- **Maven 3.9.14**  
   [下載連結](https://maven.apache.org/download.cgi)
 
 ---

--- a/backend/build.bat
+++ b/backend/build.bat
@@ -40,12 +40,12 @@ REM Convert Windows path to Docker path format
 set "HOST_DIR_DOCKER=%HOST_DIR:\=/%"
 
 REM Use Docker to extract artifactId
-for /f "tokens=*" %%a in ('docker run --rm -v "%HOST_DIR_DOCKER%:/app" -w "%CONTAINER_WORKDIR%" maven:3.9.9-eclipse-temurin-21 mvn help:evaluate -Dexpression^=project.artifactId -q -DforceStdout') do (
+for /f "tokens=*" %%a in ('docker run --rm -v "%HOST_DIR_DOCKER%:/app" -w "%CONTAINER_WORKDIR%" maven:3.9.14-eclipse-temurin-25 mvn help:evaluate -Dexpression^=project.artifactId -q -DforceStdout') do (
     set "APP_NAME=%%a"
 )
 
 REM Use Docker to extract version
-for /f "tokens=*" %%a in ('docker run --rm -v "%HOST_DIR_DOCKER%:/app" -w "%CONTAINER_WORKDIR%" maven:3.9.9-eclipse-temurin-21 mvn help:evaluate -Dexpression^=project.version -q -DforceStdout') do (
+for /f "tokens=*" %%a in ('docker run --rm -v "%HOST_DIR_DOCKER%:/app" -w "%CONTAINER_WORKDIR%" maven:3.9.14-eclipse-temurin-25 mvn help:evaluate -Dexpression^=project.version -q -DforceStdout') do (
     set "VERSION=%%a"
 )
 
@@ -65,7 +65,7 @@ set "IMAGE_NAME=!APP_NAME!:!VERSION!"
 echo [SUCCESS] Project info: name=!APP_NAME!, version=!VERSION!, JAR=!JAR_NAME!
 
 echo [INFO] Building Maven project...
-docker run --rm -v "%HOST_DIR_DOCKER%:/app" -w "%CONTAINER_WORKDIR%" maven:3.9.9-eclipse-temurin-21 mvn clean package -DskipTests
+docker run --rm -v "%HOST_DIR_DOCKER%:/app" -w "%CONTAINER_WORKDIR%" maven:3.9.14-eclipse-temurin-25 mvn clean package -DskipTests
 
 if %ERRORLEVEL% NEQ 0 (
     echo [ERROR] Maven build failed

--- a/backend/build.sh
+++ b/backend/build.sh
@@ -1,12 +1,12 @@
 #!/bin/bash
 
 # 腳本名稱: build.sh
-# 用途: 使用 maven:3.9.9-eclipse-temurin-21 容器打包 Maven 專案，構建 Docker 鏡像，支援 monorepo 結構查找 pom.xml 和 Dockerfile，動態查找 .backendEnv
+# 用途: 使用 maven:3.9.14-eclipse-temurin-25 容器打包 Maven 專案，構建 Docker 鏡像，支援 monorepo 結構查找 pom.xml 和 Dockerfile，動態查找 .backendEnv
 # 使用方式: chmod +x build.sh && ./build.sh
 
 # 配置參數
 DOCKERFILE="Dockerfile"
-MAVEN_IMAGE="maven:3.9.9-eclipse-temurin-21"
+MAVEN_IMAGE="maven:3.9.14-eclipse-temurin-25"
 
 # 顏色輸出函數
 RED='\033[0;31m'


### PR DESCRIPTION
### Motivation
- 把後端容器與建置映像升級到 JDK 25 與 Maven 最新穩定版以維持安全性與與本地開發環境一致性。

### Description
- 將 `backend/Dockerfile` 的 builder 與 runtime 基底映像從 `eclipse-temurin:21-jre-alpine` 改為 `eclipse-temurin:25-jre-alpine`。
- 將 `backend/build.sh` 與 `backend/build.bat` 中的 Maven Docker image 從 `maven:3.9.9-eclipse-temurin-21` 更新為 `maven:3.9.14-eclipse-temurin-25`，以在容器建置時使用 Maven 3.9.14 + JDK25 環境。
- 更新 `backend/README.md` 的環境需求為 `OpenJDK 25` 與 `Maven 3.9.14` 並修正 JDK 下載錨點與版本描述。
- 變更檔案：`backend/Dockerfile`、`backend/build.sh`、`backend/build.bat`、`backend/README.md`。

### Testing
- 在本地執行 `cd backend && mvn clean install`（使用本機 Maven/JDK）結果為 `BUILD SUCCESS`，專案能以 JDK 25 編譯通過。
- 嘗試在容器中使用 `docker run --rm -v /workspace/TravelPlanWithAccounting:/app -w /app/backend maven:3.9.14-eclipse-temurin-25 mvn clean install` 進行驗證時失敗，原因為執行環境缺少 Docker（`docker: command not found`）。
- 已執行 `cd backend && java -version && mvn -version` 以確認本機 Java 為 JDK 25；Maven 版本視執行者環境而定，但容器化建置已指向 `maven:3.9.14-eclipse-temurin-25`。

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69d0ef71f67c8323b0ddcb0db5f6e5f3)