### PR TITLE
Add repository AGENTS.md and initial root/backend skill scaffolding per agent-system PRD

### DIFF
--- a/.agents/skills/create-prd/SKILL.md
+++ b/.agents/skills/create-prd/SKILL.md
@@ -1,0 +1,34 @@
+---
+name: create-prd
+description: Use when requirements are ambiguous or new features are being proposed; convert intent into a structured, testable PRD with explicit scope and risks.
+---
+
+# create-prd
+
+## Purpose
+Turn ambiguous requirements into executable product requirements.
+
+## Trigger Conditions
+- New feature request
+- Large change with unclear acceptance criteria
+
+## Inputs
+- User goals
+- Project constraints from scan
+
+## Steps
+1. Define problem statement and desired outcomes.
+2. Specify scope and non-goals.
+3. List user scenarios and acceptance criteria.
+4. Capture assumptions, dependencies, and risks.
+
+## Outputs
+- Structured PRD draft
+- Open questions requiring confirmation
+
+## Boundaries
+- Do not jump straight to implementation details when problem is still unclear.
+
+## Verification
+- Ensure acceptance criteria are testable.
+- Ensure assumptions are clearly marked.

--- a/.agents/skills/plan-work/SKILL.md
+++ b/.agents/skills/plan-work/SKILL.md
@@ -1,0 +1,34 @@
+---
+name: plan-work
+description: Use after PRD or bug context is available to classify task type, define execution sequence, and set validation strategy before coding.
+---
+
+# plan-work
+
+## Purpose
+Create an implementation-ready execution plan.
+
+## Trigger Conditions
+- After PRD completion
+- Before meaningful code changes
+
+## Inputs
+- PRD or bug context
+- Repository scan findings
+
+## Steps
+1. Classify task type (feature/bug/security/refactor/docs).
+2. Define impacted modules and risk level.
+3. Propose minimal sequence of skills/actions.
+4. Define validation commands and escalation points.
+
+## Outputs
+- Ordered work plan
+- Validation plan
+- Explicit escalation checkpoints
+
+## Boundaries
+- Do not execute risky decisions without user confirmation.
+
+## Verification
+- Confirm scope, order, and validation are consistent with repo conventions.

--- a/.agents/skills/scan-project/SKILL.md
+++ b/.agents/skills/scan-project/SKILL.md
@@ -1,0 +1,37 @@
+---
+name: scan-project
+description: Use when entering an unfamiliar repo or before generating/updating AGENTS.md and skills; map real structure, commands, and constraints without guessing.
+---
+
+# scan-project
+
+## Purpose
+Produce a factual project scan to support planning or rule updates.
+
+## Trigger Conditions
+- First task in an unfamiliar repository.
+- Before creating/updating `AGENTS.md` or `SKILL.md` files.
+
+## Inputs
+- User request
+- Existing repository files
+
+## Steps
+1. Identify top-level directories and key docs.
+2. Detect existing `AGENTS.md` files and scope hierarchy.
+3. Identify runnable commands from real scripts/manifests.
+4. Separate confirmed facts from assumptions.
+
+## Outputs
+- Directory and module summary
+- Confirmed build/test/run commands
+- Known constraints and risks
+- `REQUIRES CONFIRMATION` list
+
+## Boundaries
+- Never fabricate commands or architecture details.
+- Keep scan concise and actionable.
+
+## Verification
+- Re-check cited file paths exist.
+- Ensure each command/output claim is evidence-based.

--- a/.agents/skills/verify-change/SKILL.md
+++ b/.agents/skills/verify-change/SKILL.md
@@ -1,0 +1,33 @@
+---
+name: verify-change
+description: Use for high-level verification of documentation or small-scope changes to confirm completeness, consistency, and unresolved risks.
+---
+
+# verify-change
+
+## Purpose
+Perform lightweight but explicit verification before handoff.
+
+## Trigger Conditions
+- Docs/config/rules updates
+- Small non-invasive code changes
+
+## Inputs
+- Changed files
+- Relevant repository rules
+
+## Steps
+1. Check changed content against stated requirements.
+2. Validate references, paths, and command claims.
+3. Report verified vs unverified items.
+
+## Outputs
+- Verification checklist with pass/gap status
+- Remaining risks and follow-up checks
+
+## Boundaries
+- Do not invent test results.
+- If environment blocks a check, report limitation explicitly.
+
+## Verification
+- Ensure every conclusion maps to inspected files or executed commands.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,57 @@
+# AGENTS.md
+
+## Scope
+
+This file applies to the entire repository.
+For files under `backend/`, `backend/AGENTS.md` has higher priority.
+
+## Repository Overview
+
+- Monorepo currently centered on a Spring Boot backend service under `backend/`.
+- Product/process documents are under `docs/`.
+- Agent system design source of truth is `docs/agent-system-PRD.md`.
+
+## Important Directories
+
+- `backend/`: Java/Spring Boot application source and tests.
+- `backend/docs/`: backend-specific docs and migration notes.
+- `docs/`: repository-level planning docs.
+- `.agents/skills/`: root reusable skills for planning and governance workflows.
+
+## Working Conventions
+
+1. Prefer smallest correct change; avoid broad refactors unless explicitly requested.
+2. Read relevant files before editing.
+3. Do not invent commands, paths, or versions. Use `REQUIRES CONFIRMATION` when uncertain.
+4. Keep durable rules in `AGENTS.md`, and put reusable multi-step workflows in skills.
+5. For backend tasks, follow Controller → Service → Repository layering and defer to `backend/AGENTS.md`.
+
+## Build / Test / Validation Overview
+
+- Backend commands should be executed from `backend/`.
+- Preferred checks (when backend code changes):
+  - `./mvnw test`
+  - `./mvnw clean install`
+- If command cannot run, report what is unverified and why.
+
+## Do-Not Rules
+
+- Do not overwrite existing `backend/AGENTS.md` wholesale when patching is sufficient.
+- Do not auto-apply high-risk changes (DB schema, auth/security flow, API breaking contract, dependencies) without confirmation.
+- Do not claim validation passed unless command was actually run.
+
+## Routing Guidance
+
+- Unknown repo or unclear context: use `scan-project` first.
+- Requirement shaping / doc planning: use `create-prd`, then `plan-work`.
+- Cross-file or docs-only checks: use `verify-change`.
+- Backend implementation/testing/review/refactor: enter `backend/` scope and use backend skills.
+
+## Definition of Done
+
+Before handoff, always include:
+
+1. What changed and why.
+2. Files touched.
+3. Commands actually run and outcomes.
+4. Remaining risks, assumptions, or unverified areas.

--- a/backend/.agents/skills/backend-test-verification/SKILL.md
+++ b/backend/.agents/skills/backend-test-verification/SKILL.md
@@ -1,0 +1,33 @@
+---
+name: backend-test-verification
+description: Use after backend code changes to run and report concrete Maven validation commands with honest pass/fail and explicit unverified gaps.
+---
+
+# backend-test-verification
+
+## Purpose
+Provide trustworthy verification status for backend changes.
+
+## Trigger Conditions
+- Backend code has been modified.
+- Pre-handoff validation is needed.
+
+## Inputs
+- Changed backend files
+- Available Maven commands/environment
+
+## Steps
+1. Run smallest relevant test/build command first.
+2. Escalate to broader command when needed (e.g., `./mvnw test`, `./mvnw clean install`).
+3. Capture failures, warnings, and environment blockers.
+
+## Outputs
+- Exact commands executed
+- Pass/fail status and error summary
+- Unverified areas
+
+## Boundaries
+- Never claim checks passed unless actually executed.
+
+## Verification
+- Ensure report reflects real terminal output only.

--- a/backend/.agents/skills/implement-backend-change/SKILL.md
+++ b/backend/.agents/skills/implement-backend-change/SKILL.md
@@ -1,0 +1,35 @@
+---
+name: implement-backend-change
+description: Use for backend code implementation after planning is clear; apply minimal safe changes following Controller-Service-Repository conventions and existing project patterns.
+---
+
+# implement-backend-change
+
+## Purpose
+Implement backend tasks safely and consistently.
+
+## Trigger Conditions
+- Task is approved and sufficiently clarified.
+- Change primarily affects backend application code.
+
+## Inputs
+- Approved task plan
+- `backend/AGENTS.md` rules
+- Existing module patterns
+
+## Steps
+1. Locate impacted controller/service/repository/dto paths.
+2. Reuse existing utilities and conventions.
+3. Apply smallest correct code change.
+4. Update docs/messages/annotations only when required by behavior change.
+
+## Outputs
+- Backend code patch
+- Short change summary with impacted files
+
+## Boundaries
+- No silent API contract breaks.
+- No DB schema/auth/dependency changes without confirmation.
+
+## Verification
+- Run at least one relevant backend validation command when feasible.

--- a/backend/.agents/skills/refactor-backend/SKILL.md
+++ b/backend/.agents/skills/refactor-backend/SKILL.md
@@ -1,0 +1,35 @@
+---
+name: refactor-backend
+description: Use for backend structure/maintainability improvements without changing externally observable behavior; require clear scope and validation.
+---
+
+# refactor-backend
+
+## Purpose
+Improve backend code quality while preserving behavior.
+
+## Trigger Conditions
+- Refactor request with no new feature intent.
+- Technical debt cleanup in bounded scope.
+
+## Inputs
+- Refactor goal and boundaries
+- Existing tests and architecture patterns
+
+## Steps
+1. Confirm non-functional scope and invariants.
+2. Apply incremental refactor in small commits.
+3. Preserve public contracts and runtime behavior.
+4. Run targeted validation for touched areas.
+
+## Outputs
+- Refactor patch
+- Behavior-preservation notes
+- Validation summary
+
+## Boundaries
+- Do not mix feature work into refactor changes.
+- Escalate if API/schema/security impact appears.
+
+## Verification
+- Confirm no intended behavior change through tests/checks.

--- a/backend/.agents/skills/review-change/SKILL.md
+++ b/backend/.agents/skills/review-change/SKILL.md
@@ -1,0 +1,34 @@
+---
+name: review-change
+description: Use to review backend changes for correctness, security, maintainability, and testing risk before delivery.
+---
+
+# review-change
+
+## Purpose
+Perform structured code review with severity grading.
+
+## Trigger Conditions
+- A backend patch is ready for review.
+- Security or correctness confidence is needed.
+
+## Inputs
+- Diff/changed files
+- Backend rules and conventions
+
+## Steps
+1. Check correctness against requirements.
+2. Check security-sensitive surfaces and error handling.
+3. Check maintainability and style consistency.
+4. Check validation sufficiency and regressions.
+5. Classify issues by severity (P0-P3).
+
+## Outputs
+- Review findings with file/line references
+- Delivery recommendation (ship / fix required)
+
+## Boundaries
+- Keep findings actionable and evidence-based.
+
+## Verification
+- Ensure each finding maps to concrete code evidence.


### PR DESCRIPTION
### Motivation

- 依照 `docs/agent-system-PRD.md` 的 Phase‑1 指引，補齊 repository 層級的 durable guidance 並建立第一輪可重用 skills，以便後續 agent 工作流可穩定觸發與驗證。 
- 採用 inspect‑and‑patch 原則保留專案特有規則，避免覆蓋已有的 `backend/AGENTS.md`，以降低破壞既有專案知識的風險。

### Description

- 在專案根目錄新增 `AGENTS.md`，包含 scope、repo overview、routing guidance、Do‑Not rules、Definition of Done 與 build/test 建議等基本規則。 
- 新增 4 個 root skills（每個含 `name`/`description` frontmatter 與流程說明）：`.agents/skills/scan-project/SKILL.md`、`.agents/skills/create-prd/SKILL.md`、`.agents/skills/plan-work/SKILL.md`、`.agents/skills/verify-change/SKILL.md`。 
- 新增 4 個 backend skills（每個含 frontmatter 與驗證/邊界說明）：`backend/.agents/skills/implement-backend-change/SKILL.md`、`backend/.agents/skills/backend-test-verification/SKILL.md`、`backend/.agents/skills/review-change/SKILL.md`、`backend/.agents/skills/refactor-backend/SKILL.md`。 
- 已完整讀取並檢查現有 `backend/AGENTS.md`，依規則保留其內容（未修改），並將新增檔案提交到版本控制（commit `aaacb62`）。

### Testing

- 使用 `find` 與 `rg` 檢查新建 `SKILL.md` 的檔案路徑與 frontmatter（`name`/`description`）是否存在，檢查結果均通過。 
- 執行 `git add` / `git commit` 並確認 commit `aaacb62` 已建立成功。 
- 沒有執行後端編譯或單元測試（例如 `./mvnw test` 或 `./mvnw clean install`），原因是本次變更僅為文件與 skill scaffold，未修改 Java runtime 邏輯，因此依最小驗證策略只做結構與 frontmatter 驗證；後續若需要，建議執行完整 Maven 驗證以確保整體集成無誤。 
- 主要執行過的命令包括 `find`、`rg`、`nl`、`git status`、`git add`、`git commit` 與 PR 建檔工具（`make_pr`），皆已成功執行。

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69d1fa7c8388832383709c334d2f16b5)