### PR TITLE
Enhance scan-project skill to generate reusable project architecture snapshot

### DIFF
--- a/.agents/skills/scan-project/SKILL.md
+++ b/.agents/skills/scan-project/SKILL.md
@@ -1,37 +1,79 @@
 ---
 name: scan-project
-description: Use when entering an unfamiliar repo or before generating/updating AGENTS.md and skills; map real structure, commands, and constraints without guessing.
+description: Use when entering an unfamiliar repo or before generating/updating AGENTS.md and skills; map real structure, commands, and constraints without guessing, then produce a reusable architecture snapshot for future agent guidance.
 ---
 
 # scan-project
 
 ## Purpose
-Produce a factual project scan to support planning or rule updates.
+Produce a factual, reproducible project scan that supports planning, AGENTS.md updates, and future onboarding.
+
+## Why this design
+- Keep docs close to code and maintain them in version control (GitHub repository documentation guidance).
+- Use lightweight architecture documentation that teams can actually maintain (arc42 + C4 model).
+- Capture important trade-off decisions as ADR links when present.
 
 ## Trigger Conditions
 - First task in an unfamiliar repository.
-- Before creating/updating `AGENTS.md` or `SKILL.md` files.
+- Before creating/updating `AGENTS.md` or any `SKILL.md`.
+- Before proposing broad refactors across modules.
 
 ## Inputs
-- User request
+- User request and current goal
 - Existing repository files
+- Existing architecture docs (`docs/`, `README*`, ADR folders, diagrams)
 
 ## Steps
-1. Identify top-level directories and key docs.
-2. Detect existing `AGENTS.md` files and scope hierarchy.
-3. Identify runnable commands from real scripts/manifests.
-4. Separate confirmed facts from assumptions.
+1. **Scan structure (facts only)**
+   - List top-level directories and identify code modules.
+   - Detect major manifests/build files and infer toolchain from those files only.
+2. **Detect governance and scope rules**
+   - Find all `AGENTS.md` files.
+   - Build scope precedence map (root to nested overrides).
+3. **Extract runnable commands from evidence**
+   - Read scripts/wrappers/manifests to collect build/test/lint/run commands.
+   - Mark unknowns as `REQUIRES CONFIRMATION` instead of guessing.
+4. **Summarize architecture at practical depth**
+   - Identify system context, main containers/apps, key components, and data boundaries.
+   - Link each architecture claim to specific files.
+5. **Generate architecture snapshot document**
+   - Create or update `docs/project-architecture.md` using the template in `templates/project-architecture-template.md`.
+   - Ensure this file is concise and usable as input for future `AGENTS.md` maintenance.
+6. **Report confidence and gaps**
+   - Separate confirmed facts vs assumptions.
+   - Add unknowns and validation follow-ups.
 
-## Outputs
-- Directory and module summary
-- Confirmed build/test/run commands
-- Known constraints and risks
-- `REQUIRES CONFIRMATION` list
+## Required Outputs
+1. **Scan summary in response**
+   - Directory/module summary
+   - AGENTS scope hierarchy
+   - Confirmed commands
+   - Constraints and risks
+   - `REQUIRES CONFIRMATION` list
+2. **Persistent artifact**
+   - `docs/project-architecture.md` (new or updated)
+
+## `docs/project-architecture.md` quality bar
+- Must include exact date (`YYYY-MM-DD`) and scan scope.
+- Must cite concrete file paths for key claims.
+- Must distinguish:
+  - Confirmed
+  - Inferred
+  - Unknown / `REQUIRES CONFIRMATION`
+- Must include a "How to update" section so future agents can refresh quickly.
 
 ## Boundaries
-- Never fabricate commands or architecture details.
-- Keep scan concise and actionable.
+- Never fabricate commands, ownership, architecture, or dependencies.
+- Prefer shortest accurate scan first; deepen only where task requires.
+- Do not edit unrelated docs while generating the architecture snapshot.
 
 ## Verification
-- Re-check cited file paths exist.
-- Ensure each command/output claim is evidence-based.
+- Re-check every cited file path exists.
+- Re-run minimal commands used for evidence collection when output is ambiguous.
+- Confirm `docs/project-architecture.md` is internally consistent with the scan summary.
+
+## External references used by this skill design
+- GitHub Docs, repository documentation best practices: https://docs.github.com/en/repositories/creating-and-managing-repositories/best-practices-for-repositories
+- arc42 template overview: https://arc42.org/
+- C4 model (official): https://c4model.com/
+- ADR hub and rationale references: https://adr.github.io/

--- a/.agents/skills/scan-project/templates/project-architecture-template.md
+++ b/.agents/skills/scan-project/templates/project-architecture-template.md
@@ -1,0 +1,63 @@
+# Project Architecture Snapshot
+
+- Scan date: YYYY-MM-DD
+- Repository: <repo-name>
+- Scan scope: <full repo | subdirectory>
+- Source commit: <git sha>
+
+## 1) System Context (Confirmed)
+- Product/domain objective:
+- Primary users/actors:
+- External systems/services:
+- Evidence:
+
+## 2) Containers / Deployable Units (Confirmed)
+| Container | Path | Runtime/Framework | Responsibility |
+|---|---|---|---|
+| example-backend | backend/ | Spring Boot | API + domain services |
+
+## 3) Component View (Confirmed + Inferred)
+### 3.1 Confirmed components
+- Component:
+  - Path:
+  - Responsibility:
+  - Depends on:
+  - Evidence:
+
+### 3.2 Inferred components (mark clearly)
+- Inference:
+  - Why inferred:
+  - What to verify:
+
+## 4) Data and Integration Boundaries
+- Datastores:
+- Message/event integrations:
+- Third-party APIs:
+- Secrets/config boundaries:
+- Evidence:
+
+## 5) Build / Test / Run Commands (Confirmed)
+| Purpose | Command | Source file/path |
+|---|---|---|
+| test | ./mvnw test | backend/AGENTS.md |
+
+## 6) Agent Governance Map
+- AGENTS precedence chain:
+  1.
+  2.
+- Additional local rules (if any):
+
+## 7) Risks / Unknowns / REQUIRES CONFIRMATION
+- Unknown:
+  - Why unknown:
+  - How to confirm:
+
+## 8) Suggested `AGENTS.md` Implications
+- Durable rules worth keeping in AGENTS:
+- Workflow details better kept in skills:
+
+## 9) How to Update This Snapshot
+1. Re-run scan-project.
+2. Refresh module map and command table from manifests/scripts.
+3. Update evidence links and unknowns.
+4. Keep only currently true facts; remove stale statements.

--- a/docs/project-architecture.md
+++ b/docs/project-architecture.md
@@ -1,0 +1,125 @@
+# Project Architecture Snapshot
+
+- Scan date: 2026-04-05
+- Repository: TravelPlanWithAccounting
+- Scan scope: full repository
+- Source commit: 0599ee0
+
+## 1) System Context
+
+### Confirmed
+- Repository is positioned as a travel itinerary + accounting project (`TravelPlanWithAccounting`).
+- It contains a Spring Boot backend service and a Next.js frontend application.
+- Main backend domain package is `com.travelPlanWithAccounting.service`.
+
+Evidence:
+- `README.md`
+- `backend/pom.xml`
+- `frontend/package.json`
+- `backend/src/main/java/com/travelPlanWithAccounting/service/*`
+
+### Inferred
+- External actors likely include end users through Web UI and REST API clients.
+
+### REQUIRES CONFIRMATION
+- Exact production deployment topology and external runtime dependencies (cloud services, ingress, observability stack).
+
+## 2) Containers / Deployable Units
+
+| Container | Path | Runtime/Framework | Responsibility |
+|---|---|---|---|
+| backend-service | `backend/` | Java 25, Spring Boot 4.0.4, Spring Data JPA | Core API and domain/business logic |
+| frontend | `frontend/` | Next.js 15, React 19, TypeScript | Web UI and client-side integration |
+
+Evidence:
+- `backend/pom.xml`
+- `frontend/package.json`
+
+## 3) Component View
+
+### 3.1 Confirmed components
+- Backend layered components exist under `service/` package:
+  - `controller/`
+  - `service/`
+  - `repository/`
+  - `mapper/`
+  - `dto/`
+  - `validator/`
+  - plus cross-cutting areas (`aspect/`, `config/`, `security/`, `exception/`, `message/`).
+
+Evidence:
+- `backend/src/main/java/com/travelPlanWithAccounting/service/` directory tree
+- `backend/AGENTS.md`
+
+### 3.2 Inferred components
+- Frontend likely follows Next.js app-router conventions and consumes backend APIs via `axios`.
+
+Why inferred:
+- Dependency list includes `next`, `react`, and `axios`; detailed route/component mapping not fully scanned.
+
+What to verify:
+- `frontend/src` routing layout and API client boundaries.
+
+## 4) Data and Integration Boundaries
+
+### Confirmed
+- Backend uses PostgreSQL through Spring Data JPA.
+- Security/auth infrastructure exists (`spring-boot-starter-security`, JWT dependencies).
+- OpenAPI UI support is included through `springdoc-openapi-starter-webmvc-ui`.
+
+Evidence:
+- `backend/pom.xml`
+- `backend/AGENTS.md`
+
+### REQUIRES CONFIRMATION
+- Actual DB schema ownership and migration mechanism (Flyway/Liquibase/manual).
+- Third-party API endpoints and outbound integration contracts.
+- Cache/message broker runtime topology.
+
+## 5) Build / Test / Run Commands (Confirmed)
+
+| Purpose | Command | Source |
+|---|---|---|
+| backend test | `cd backend && ./mvnw test` | `AGENTS.md` |
+| backend build | `cd backend && ./mvnw clean install` | `AGENTS.md` |
+| frontend dev | `cd frontend && npm run dev` | `frontend/README.md` + `frontend/package.json` |
+| frontend build | `cd frontend && npm run build` | `frontend/package.json` |
+| frontend lint | `cd frontend && npm run lint` | `frontend/package.json` |
+
+## 6) Agent Governance Map
+
+AGENTS precedence chain:
+1. `AGENTS.md` (repository-wide)
+2. `backend/AGENTS.md` (overrides root rules under `backend/`)
+
+Additional note:
+- Root repository defines reusable skills in `.agents/skills/`.
+
+## 7) Risks / Unknowns / REQUIRES CONFIRMATION
+
+- Unknown: production deployment architecture.
+  - Why unknown: no infra/deployment manifest scanned in this pass.
+  - How to confirm: inspect CI/CD pipelines, IaC, or ops docs.
+- Unknown: authoritative architecture decision history.
+  - Why unknown: no ADR folder convention explicitly found in this pass.
+  - How to confirm: search for `adr` or decision logs under `docs/`.
+
+## 8) Suggested `AGENTS.md` Implications
+
+Durable rules suitable for AGENTS:
+- Keep backend layering (Controller → Service → Repository).
+- Require evidence-based command extraction from manifests/docs.
+- Keep unknowns explicitly labeled as `REQUIRES CONFIRMATION`.
+
+Workflow details better kept in skills:
+- Exact scan command sequence.
+- Architecture snapshot generation checklist.
+- Refresh cadence and diff review process for architecture docs.
+
+## 9) How to Update This Snapshot
+
+1. Re-run `scan-project` skill.
+2. Refresh module map from real directories and manifests.
+3. Update command table from scripts/wrappers.
+4. Keep only confirmed facts and mark unknowns clearly.
+5. Reconcile with current `AGENTS.md` precedence and repository conventions.


### PR DESCRIPTION
### Motivation
- 讓 `scan-project` 不只回傳掃描結果，而是能產出可被後續 `AGENTS.md` 與 skills 重用的版本化架構快照（減少臆測並把知識留在 repo 裡）。
- 強化掃描流程以依證據提取可執行命令、AGENTS 範圍優先權與系統邊界，並把不確定事項標註為 `REQUIRES CONFIRMATION`。 
- 設計時參考的外部來源：GitHub 文件實務指南 `https://docs.github.com/en/repositories/creating-and-managing-repositories/best-practices-for-repositories`、arc42 `https://arc42.org/`、C4 model `https://c4model.com/`、ADR hub `https://adr.github.io/`。

### Description
- 主要變更：擴充 `.agents/skills/scan-project/SKILL.md`，把掃描步驟、輸出、品質門檻與驗證流程明確化，並要求產生持久化的架構檔。 
- 新增檔案：增加模板檔 `.agents/skills/scan-project/templates/project-architecture-template.md` 以統一輸出格式，並根據當前倉儲狀態建立初版 `docs/project-architecture.md`。 
- 變更檔案清單（觸碰的檔案）：` .agents/skills/scan-project/SKILL.md`、`.agents/skills/scan-project/templates/project-architecture-template.md`、`docs/project-architecture.md`。 
- 其他注意事項與風險：輸出檔中包含 `Inferred` 與 `REQUIRES CONFIRMATION` 區塊（例如生產部署拓撲、DB migration 工具、第三方整合終端點需進一步確認）。

### Testing
- 自動化測試：此次變更為 docs/skill 層級，未執行任何應用程式自動化測試（例如 `./mvnw test` 未執行），因為變更不影響程式碼邏輯或建置設定。 
- 已執行的驗證命令（確認與結果）：執行並成功獲得證據包括 `sed` / `find` / `cat` 等檔案檢視命令以擷取 `AGENTS.md`、`backend/pom.xml`、`frontend/package.json` 與目錄結構，並已建立與提交變更（`git commit` 成功）。
- 建議後續驗證：若需同時驗證後端行為，請在 `backend/` 執行 `./mvnw test` 或 `./mvnw clean install`，以驗證建置與測試通過與否（此步驟屬選項，未在本次變更中執行）。

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69d213028a948323bb1c6eb75273fc9e)