### PR TITLE
docs: refresh project architecture snapshot (full frontend + backend scan)

### DIFF
--- a/docs/project-architecture.md
+++ b/docs/project-architecture.md
@@ -1,125 +1,134 @@
 # Project Architecture Snapshot
 
-- Scan date: 2026-04-05
+- Scan date: 2026-04-06
 - Repository: TravelPlanWithAccounting
-- Scan scope: full repository
-- Source commit: 0599ee0
+- Scan scope: full repository (frontend + backend + docs + skills)
+- Source commit at scan start: 4fe8d4e
 
-## 1) System Context
+## 1) Directory and Module Distribution
 
 ### Confirmed
-- Repository is positioned as a travel itinerary + accounting project (`TravelPlanWithAccounting`).
-- It contains a Spring Boot backend service and a Next.js frontend application.
-- Main backend domain package is `com.travelPlanWithAccounting.service`.
+- Monorepo root contains three primary work areas:
+  - `backend/`: Spring Boot API service.
+  - `frontend/`: Next.js web app.
+  - `docs/`: product/process and architecture-related docs.
+- Agent governance and reusable workflows live under `.agents/skills/`.
 
 Evidence:
-- `README.md`
+- `AGENTS.md`
 - `backend/pom.xml`
 - `frontend/package.json`
-- `backend/src/main/java/com/travelPlanWithAccounting/service/*`
+- `docs/agent-system-PRD.md`
+- `.agents/skills/scan-project/SKILL.md`
 
-### Inferred
-- External actors likely include end users through Web UI and REST API clients.
-
-### REQUIRES CONFIRMATION
-- Exact production deployment topology and external runtime dependencies (cloud services, ingress, observability stack).
-
-## 2) Containers / Deployable Units
-
-| Container | Path | Runtime/Framework | Responsibility |
-|---|---|---|---|
-| backend-service | `backend/` | Java 25, Spring Boot 4.0.4, Spring Data JPA | Core API and domain/business logic |
-| frontend | `frontend/` | Next.js 15, React 19, TypeScript | Web UI and client-side integration |
-
-Evidence:
-- `backend/pom.xml`
-- `frontend/package.json`
-
-## 3) Component View
-
-### 3.1 Confirmed components
-- Backend layered components exist under `service/` package:
-  - `controller/`
-  - `service/`
-  - `repository/`
-  - `mapper/`
-  - `dto/`
-  - `validator/`
-  - plus cross-cutting areas (`aspect/`, `config/`, `security/`, `exception/`, `message/`).
+### Backend distribution (confirmed)
+- Build/runtime files: `backend/pom.xml`, `backend/mvnw`, `backend/Dockerfile`, `backend/docker-compose.yml`.
+- Source layout:
+  - `backend/src/main/java/com/travelPlanWithAccounting/service/` (application code)
+  - `backend/src/main/resources/` (i18n/static/config resources)
+  - `backend/src/test/java/com/travelPlanWithAccounting/` (tests)
+- Main backend packages include:
+  - `controller`, `service`, `repository`, `mapper`, `dto`, `entity`
+  - cross-cutting/support: `aspect`, `config`, `security`, `validator`, `message`, `exception`, `util`.
 
 Evidence:
 - `backend/src/main/java/com/travelPlanWithAccounting/service/` directory tree
 - `backend/AGENTS.md`
 
-### 3.2 Inferred components
-- Frontend likely follows Next.js app-router conventions and consumes backend APIs via `axios`.
+### Frontend distribution (confirmed)
+- Build/runtime files: `frontend/package.json`, `frontend/pnpm-lock.yaml`, `frontend/next.config.ts`, `frontend/Dockerfile`.
+- Source layout:
+  - `frontend/src/app/` uses App Router style (`layout.tsx`, route segments, API routes under `app/api/`)
+  - localized route segment under `frontend/src/app/[lng]/`
+  - shared UI components under `frontend/src/app/components/`
+  - i18n resources under `frontend/src/app/i18n/locales/{en,zh}`
+  - middleware at `frontend/src/middleware.ts`
 
-Why inferred:
-- Dependency list includes `next`, `react`, and `axios`; detailed route/component mapping not fully scanned.
+Evidence:
+- `frontend/src/app/` directory tree
+- `frontend/src/middleware.ts`
+- `frontend/src/app/api/_utils/http.ts`
 
-What to verify:
-- `frontend/src` routing layout and API client boundaries.
-
-## 4) Data and Integration Boundaries
+## 2) Toolchain and Runtime Baseline
 
 ### Confirmed
-- Backend uses PostgreSQL through Spring Data JPA.
-- Security/auth infrastructure exists (`spring-boot-starter-security`, JWT dependencies).
-- OpenAPI UI support is included through `springdoc-openapi-starter-webmvc-ui`.
+- Backend:
+  - Java 25 (`<java.version>25</java.version>`)
+  - Spring Boot 4.0.4 parent
+  - Spring Data JPA + PostgreSQL runtime dependency
+  - Spring Security + JJWT
+  - OpenAPI via `springdoc-openapi-starter-webmvc-ui`
+- Frontend:
+  - Next.js 15.3.0
+  - React 19
+  - TypeScript 5
+  - `axios`, `@tanstack/react-query`, and `i18next` family
 
 Evidence:
 - `backend/pom.xml`
+- `frontend/package.json`
+
+## 3) Architecture and Data Boundaries
+
+### Confirmed
+- Backend architecture expectation is layered Controller → Service → Repository, with explicit backend scope guidance.
+- Frontend includes server-side API route handlers (`app/api/**/route.ts`) that can act as BFF-style boundaries.
+- Frontend API utility builds backend clients from `NEXT_PUBLIC_API_BASE_URL`, applies `Accept-Language`, and can attach access token from cookies.
+
+Evidence:
 - `backend/AGENTS.md`
+- `frontend/src/app/api/_utils/http.ts`
+- `frontend/src/app/api/auth/verify/route.ts`
+- `frontend/src/app/api/members/auth-flow/route.ts`
 
-### REQUIRES CONFIRMATION
-- Actual DB schema ownership and migration mechanism (Flyway/Liquibase/manual).
-- Third-party API endpoints and outbound integration contracts.
-- Cache/message broker runtime topology.
+### Inferred
+- Request flow likely follows Browser → Next.js (UI + route handlers) → Spring Boot backend API.
 
-## 5) Build / Test / Run Commands (Confirmed)
+Why inferred:
+- Both Next.js route handlers and backend API service are present; no explicit deployment topology doc in this scan.
 
-| Purpose | Command | Source |
-|---|---|---|
-| backend test | `cd backend && ./mvnw test` | `AGENTS.md` |
-| backend build | `cd backend && ./mvnw clean install` | `AGENTS.md` |
-| frontend dev | `cd frontend && npm run dev` | `frontend/README.md` + `frontend/package.json` |
-| frontend build | `cd frontend && npm run build` | `frontend/package.json` |
-| frontend lint | `cd frontend && npm run lint` | `frontend/package.json` |
+## 4) Confirmed Runnable Commands (from repository evidence)
 
-## 6) Agent Governance Map
+| Area | Purpose | Command | Evidence |
+|---|---|---|---|
+| backend | test | `cd backend && ./mvnw test` | `AGENTS.md`, `backend/AGENTS.md` |
+| backend | full build | `cd backend && ./mvnw clean install` | `AGENTS.md`, `backend/AGENTS.md` |
+| backend | container build/run helper | `cd backend && sh build.sh` | `backend/README.md`, `backend/build.sh` |
+| backend | compose up/down | `cd backend && sh up.sh` / `sh down.sh` | `backend/README.md`, `backend/up.sh`, `backend/down.sh` |
+| frontend | dev | `cd frontend && npm run dev` | `frontend/README.md`, `frontend/package.json` |
+| frontend | build | `cd frontend && npm run build` | `frontend/package.json` |
+| frontend | lint | `cd frontend && npm run lint` | `frontend/package.json` |
 
-AGENTS precedence chain:
-1. `AGENTS.md` (repository-wide)
-2. `backend/AGENTS.md` (overrides root rules under `backend/`)
+## 5) AGENTS Scope / Governance Map
 
-Additional note:
-- Root repository defines reusable skills in `.agents/skills/`.
+### Confirmed precedence
+1. Root `AGENTS.md` applies to whole repository.
+2. `backend/AGENTS.md` overrides rules for `backend/` subtree.
+3. Reusable process skills are defined under `.agents/skills/`.
 
-## 7) Risks / Unknowns / REQUIRES CONFIRMATION
+## 6) Unknowns and REQUIRES CONFIRMATION
 
-- Unknown: production deployment architecture.
-  - Why unknown: no infra/deployment manifest scanned in this pass.
-  - How to confirm: inspect CI/CD pipelines, IaC, or ops docs.
-- Unknown: authoritative architecture decision history.
-  - Why unknown: no ADR folder convention explicitly found in this pass.
-  - How to confirm: search for `adr` or decision logs under `docs/`.
+- `REQUIRES CONFIRMATION`: authoritative production deployment topology (single host vs container orchestration vs cloud managed runtime).
+- `REQUIRES CONFIRMATION`: whether frontend is always deployed with Next.js server mode or can be static/exported in any environment.
+- `REQUIRES CONFIRMATION`: database migration ownership/process (no Flyway/Liquibase evidence found in scanned manifests).
+- `REQUIRES CONFIRMATION`: CI pipeline definitions (no workflow files scanned in this pass).
 
-## 8) Suggested `AGENTS.md` Implications
+## 7) Confidence and Scan Gaps
 
-Durable rules suitable for AGENTS:
-- Keep backend layering (Controller → Service → Repository).
-- Require evidence-based command extraction from manifests/docs.
-- Keep unknowns explicitly labeled as `REQUIRES CONFIRMATION`.
+### High confidence (direct evidence)
+- Module boundaries, major manifests, and technology versions.
+- Backend layering intent and AGENTS precedence.
+- Frontend app/api/i18n folder distribution.
 
-Workflow details better kept in skills:
-- Exact scan command sequence.
-- Architecture snapshot generation checklist.
-- Refresh cadence and diff review process for architecture docs.
+### Gaps not deeply scanned in this pass
+- Every individual route/page/component behavior under frontend.
+- Every domain module interaction inside backend services.
+- Runtime infrastructure/security hardening outside code repository files.
 
-## 9) How to Update This Snapshot
+## 8) How to Update This Snapshot Quickly
 
-1. Re-run `scan-project` skill.
-2. Refresh module map from real directories and manifests.
-3. Update command table from scripts/wrappers.
-4. Keep only confirmed facts and mark unknowns clearly.
-5. Reconcile with current `AGENTS.md` precedence and repository conventions.
+1. Re-run structure scan for top-level and module-level directories (excluding heavy dependency folders like `frontend/node_modules`).
+2. Re-read `AGENTS.md` and nested `backend/AGENTS.md` to refresh governance precedence.
+3. Re-extract commands only from manifests/scripts/readmes (`package.json`, `pom.xml`, shell scripts, README docs).
+4. Re-validate architecture claims against concrete file paths; classify each claim as Confirmed / Inferred / REQUIRES CONFIRMATION.
+5. Update scan date and source commit hash.


### PR DESCRIPTION
### Motivation
- 進行完整前後端專案掃描以建立可重複的 architecture 快照，並把事實型證據寫入持久化文件以支援後續規劃與 AGENTS 規則維護。

### Description
- 啟用並執行 `scan-project` skill，掃描整個 monorepo（`backend/`, `frontend/`, `docs/`, `.agents/skills/`）並擷取目錄、主要 manifest、可執行命令與技術基線證據。 
- 更新並擴充 `docs/project-architecture.md`（掃描日期改為 `2026-04-06`），內容包含目錄分布、toolchain、架構邊界、可執行命令表與 `REQUIRES CONFIRMATION` 清單。 
- 此為文件更新（docs-only），未改動任何後端或前端程式碼或相依性。 

### Testing
- 實際執行並驗證的命令包括 `pwd`、`rg --files -g 'AGENTS.md'`、`cat AGENTS.md`、`cat backend/AGENTS.md`、`cat .agents/skills/scan-project/SKILL.md`、`find` 與多項 `rg` 搜尋、`cat` 各 README/Dockerfile/pom.json 檔案、`cat backend/build.sh`、`cat backend/up.sh`、`cat backend/down.sh`、`cat backend/docker-compose.yml`、`cat frontend/Dockerfile`、`cat frontend/src/app/api/_utils/http.ts`，以及將結果寫回 `docs/project-architecture.md` 的 heredoc 操作，所有列出的檢視/掃描命令均成功執行。 
- 變更已 commit（commit: `0c8fccd`）並透過內部 `make_pr` 工具建立 PR（標題：`docs: refresh architecture snapshot for full frontend/backend scan`）。 
- 未執行後端或前端的 build 或測試（例如 `./mvnw test` / `npm run build`）; 這些步驟未被執行且因此未驗證。 

Files changed: `docs/project-architecture.md`.
Commands run: 如上列舉（掃描/檢視/寫檔與 git commit / make_pr），且均成功執行。
Results: 文件已更新並 commit + PR 已建立。
Remaining risks / follow-up checks: 需釐清與驗證的項目包括 production 部署拓樸、DB migration 流程（Flyway/Liquibase）、以及 CI/CD pipeline 配置，這些在文件中標示為 `REQUIRES CONFIRMATION` 並建議後續針對 infra/CI 做補掃描。

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69d43a68674883239784d1bd91704062)