### PR TITLE
Add backend scan skill for Java/Spring with templates and references

### DIFF
--- a/backend/.agents/skills/scan-project-backend/SKILL.md
+++ b/backend/.agents/skills/scan-project-backend/SKILL.md
@@ -1,0 +1,105 @@
+---
+name: scan-project-backend
+description: Use when scanning the backend subtree of this repository before backend implementation/review/refactor. Build a factual architecture snapshot for Java/Spring backend modules, commands, boundaries, and risks. Also use when aligning backend structure with proven GitHub Java backend patterns and when optimizing Codex skill loading with progressive-disclosure references.
+---
+
+# scan-project-backend
+
+## Purpose
+Produce a reproducible backend-only scan for `backend/` that can be reused by future tasks without re-discovery.
+
+## Assumptions
+- Repository is a backend-centric Java/Spring project under `backend/`.
+- Scan scope is documentation + architecture discovery only (no behavior change).
+- Commands are executed from **repo root** by default. If current working directory is `backend/`, use the equivalent relative paths.
+
+## Inputs
+- User goal and affected backend scope.
+- `backend/AGENTS.md` and root `AGENTS.md`.
+- `backend/pom.xml`, `backend/mvnw`, `backend/src/main/**`, `backend/src/test/**`, `backend/docs/**`.
+
+## Minimum Evidence Commands
+### Repo root mode (preferred)
+- `find backend -name AGENTS.md -print`
+- `find backend -maxdepth 3 -type f | rg 'pom.xml|mvnw|application.*yml|README|docs'`
+- `find backend/src/main/java -maxdepth 4 -type d`
+- `find backend/src/test/java -maxdepth 4 -type d`
+- `rg --files backend/src/main/java | head -n 40`
+- `rg --files backend/src/test/java | head -n 40`
+
+### backend/ mode (equivalent)
+- `find . -name AGENTS.md -print`
+- `find . -maxdepth 3 -type f | rg 'pom.xml|mvnw|application.*yml|README|docs'`
+- `find src/main/java -maxdepth 4 -type d`
+- `find src/test/java -maxdepth 4 -type d`
+- `rg --files src/main/java | head -n 40`
+- `rg --files src/test/java | head -n 40`
+
+Use only commands supported by repository evidence. If a command fails due to environment limits, record it explicitly.
+
+## Steps
+1. **Build scope guardrails first**
+   - Read root and backend AGENTS rules.
+   - Record overlap and precedence rules that apply to `backend/`.
+2. **Scan backend structure from evidence**
+   - Map package layers: `controller`, `service`, `repository`, `dto`, `mapper`, `config`, `aspect`, `exception`, `message`.
+   - Detect infrastructure modules (security, cache, mail, integration clients, schedulers).
+3. **Extract real commands only**
+   - Pull commands from `mvnw`, `pom.xml`, and existing docs/scripts.
+   - Mark unknown commands as `REQUIRES CONFIRMATION`.
+4. **Map data + boundary surfaces**
+   - Identify entities, repositories, transaction boundaries, and outward API boundaries.
+   - Identify security/i18n response patterns used across controllers.
+5. **Classify current backend style against proven GitHub patterns**
+   - Read `references/github-java-backend-patterns.md`.
+   - Classify current state as:
+     - Layered monolith pattern
+     - Domain-modular monolith pattern
+     - Microservices split pattern
+   - Report mismatch and migration risk only as observations (no refactor proposal unless requested).
+6. **Run convention compliance check (industry + GitHub common practice)**
+   - Read `references/industry-conventions.md`.
+   - Check Maven standard layout (`src/main/java`, `src/test/java`, `src/main/resources`).
+   - Check Spring package-root arrangement and component scanning assumptions.
+   - Check repository docs discoverability (`README`, `docs/`) and backend command discoverability.
+   - Record each check as `Pass | Partial | Fail` with concrete evidence paths.
+7. **Write persistent snapshot**
+   - Create/update `backend/docs/backend-project-architecture.md` using `templates/backend-project-architecture-template.md`.
+   - Keep claims traceable to concrete file paths.
+8. **Apply Codex skill optimization checklist**
+   - Read `references/codex-skill-optimization.md`.
+   - Ensure scan output is concise, factual, and split into core + references for context efficiency.
+9. **Run miss-check before handoff**
+   - Verify there is at least one finding in each section: structure, commands, boundaries, risks.
+   - Verify unknowns are not empty when scan confidence is below high.
+   - Verify each major claim cites evidence file paths.
+
+## Required Outputs
+1. **Chat summary**
+   - Backend module map
+   - Command map
+   - Architecture classification
+   - Risks and unknowns
+   - Confidence level + why
+2. **Persistent artifact**
+   - `backend/docs/backend-project-architecture.md`
+3. **Stable output headings (for AI reusability)**
+   - `Summary`
+   - `Confirmed facts`
+   - `Inferred facts`
+   - `Unknowns (REQUIRES CONFIRMATION)`
+   - `Command map`
+   - `Convention compliance`
+   - `Risks and follow-ups`
+
+## Boundaries
+- Do not guess dependency versions, runtime profiles, or deployment topology.
+- Do not modify production code during scan.
+- Prefer smallest factual scan; deepen only for the active backend task.
+
+## Verification
+- Re-open every cited file path to confirm existence.
+- Re-run minimal evidence commands if output is ambiguous.
+- Verify architecture document clearly separates: Confirmed / Inferred / REQUIRES CONFIRMATION.
+- Verify final summary includes: files changed, commands run, results, remaining risks/follow-ups.
+- Verify no path contradiction exists between selected execution mode and produced evidence paths.

--- a/backend/.agents/skills/scan-project-backend/references/codex-skill-optimization.md
+++ b/backend/.agents/skills/scan-project-backend/references/codex-skill-optimization.md
@@ -1,0 +1,37 @@
+# Codex Skill Optimization Notes (for Backend Scan Skills)
+
+Use these rules to keep skill execution accurate and token-efficient.
+
+## Trigger quality
+- Put trigger conditions in SKILL frontmatter `description`.
+- Include both capability and context keywords (e.g., backend scan, architecture snapshot, command discovery).
+- Avoid vague trigger text.
+
+## Progressive disclosure
+- Keep `SKILL.md` focused on workflow only.
+- Move heavy detail to `references/`.
+- Link reference files directly from `SKILL.md` (one-hop discovery).
+
+## Context budget discipline
+- Load only files needed for current task scope.
+- Prefer concise checklist output over long prose.
+- Avoid duplicating the same rule across AGENTS + SKILL + references.
+
+## Determinism
+- Use evidence-first wording: "from file X" and "command output shows".
+- Mark unknowns as `REQUIRES CONFIRMATION`.
+- Never infer commands not present in repo manifests/wrappers.
+- Prefer fixed output skeletons/checklists to reduce omission risk.
+
+## Codex operational alignment
+- Reference: OpenAI Harness Engineering post (repository-embedded skills + agent workflows)
+  - https://openai.com/index/harness-engineering/
+- Local skill guidance source:
+  - `/opt/codex/skills/.system/skill-creator/SKILL.md`
+
+## Skill maintenance
+- Keep SKILL under ~500 lines.
+- Update references when backend architecture changes significantly.
+- Review trigger description when user intents change (e.g., review-only vs implementation scan).
+- Add a short "common misses" checklist whenever omissions are observed in real usage.
+- Avoid fragile external links (e.g., hardcoded non-default branches); keep branch-agnostic reference style.

--- a/backend/.agents/skills/scan-project-backend/references/github-java-backend-patterns.md
+++ b/backend/.agents/skills/scan-project-backend/references/github-java-backend-patterns.md
@@ -1,0 +1,42 @@
+# GitHub Java Backend Pattern Notes
+
+Use these references to calibrate scan findings against common Java backend repo layouts.
+
+## 1) Layered monolith baseline
+- Reference: `spring-petclinic/spring-petclinic-rest`
+- URL: https://github.com/spring-petclinic/spring-petclinic-rest
+- Useful paths:
+  - Repo root: https://github.com/spring-petclinic/spring-petclinic-rest
+  - Then inspect default branch folders: `src/main/java`, `src/test/java`
+- What to borrow for scans:
+  - Check `src/main/java` + `src/test/java` separation.
+  - Verify whether controllers/services/repositories are organized by technical layer or by domain package.
+  - Verify API docs/testing and build wrapper (`mvnw`) existence.
+
+## 2) Microservices repo split baseline
+- Reference: `spring-petclinic/spring-petclinic-microservices`
+- URL: https://github.com/spring-petclinic/spring-petclinic-microservices
+- Useful paths:
+  - Repo root: https://github.com/spring-petclinic/spring-petclinic-microservices
+  - Then inspect default branch folders: `spring-petclinic-api-gateway`, `spring-petclinic-config-server`
+- What to borrow for scans:
+  - Detect if repository is single-service or multi-service.
+  - Check for infra modules (gateway/config/discovery/observability).
+  - Check whether each service keeps independent ownership boundaries.
+
+## 3) Domain-modular monolith baseline
+- Reference: `spring-projects/spring-modulith`
+- URL: https://github.com/spring-projects/spring-modulith
+- Useful paths:
+  - https://github.com/spring-projects/spring-modulith/tree/main/spring-modulith-examples
+- What to borrow for scans:
+  - Verify root package and direct sub-packages as module boundaries.
+  - Verify module-level tests and architecture verification patterns.
+  - Distinguish module boundaries from pure technical-layer boundaries.
+
+## How to use during scan
+1. Do not force-fit the project to any pattern.
+2. Pick closest baseline and explain why with concrete file evidence.
+3. If mixed pattern exists, mark it as hybrid and list implications only.
+4. Treat references as heuristics; repository evidence remains source of truth.
+5. Check repository default branch before opening branch-specific paths.

--- a/backend/.agents/skills/scan-project-backend/references/industry-conventions.md
+++ b/backend/.agents/skills/scan-project-backend/references/industry-conventions.md
@@ -1,0 +1,48 @@
+# Industry & GitHub Convention Checks for Java Backend Scan
+
+Use this checklist to validate whether backend structure follows common conventions.
+
+## A) Maven standard directory layout (official)
+- Source: https://maven.apache.org/guides/introduction/introduction-to-the-standard-directory-layout.html
+- Expected:
+  - `src/main/java`
+  - `src/main/resources`
+  - `src/test/java`
+- Scan action:
+  1. Mark `Pass` if all standard paths exist.
+  2. Mark `Partial` if custom layout exists but can be justified by docs.
+  3. Mark `Fail` if layout is unclear and undocumented.
+
+## B) Spring package structure + component scanning baseline
+- Source: https://docs.spring.io/spring-boot/reference/using/structuring-your-code.html
+- Expected:
+  - Main application class in a root package.
+  - Components in sub-packages so default component scanning works predictably.
+- Scan action:
+  1. Verify main application class package and key component package positions.
+  2. Flag unusual cross-package scanning as risk when undocumented.
+
+## C) GitHub repository discoverability baseline
+- Source: https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/about-readmes
+- Source: https://docs.github.com/en/repositories/creating-and-managing-repositories/best-practices-for-repositories
+- Expected:
+  - Clear `README` entry points.
+  - Contribution/structure hints discoverable (docs or folder-level guidance).
+- Scan action:
+  1. Verify backend-relevant commands can be found from docs or wrappers.
+  2. Record gaps as onboarding risk, not implementation bug.
+
+## D) Branch/path robustness when referencing GitHub examples
+- Convention:
+  - Do not hardcode `master` branch paths in reusable skill references.
+  - Prefer repo URL + short note "check default branch" or use branch-agnostic guidance.
+- Scan action:
+  1. If example links are branch-specific, add fallback repo root URL.
+  2. Mark links needing manual branch confirmation as `REQUIRES CONFIRMATION`.
+
+## E) Path consistency for reproducible scans
+- Convention:
+  - A scan should not mix incompatible path bases (`backend/...` and `./...`) without explanation.
+- Scan action:
+  1. Declare execution mode (`repo-root` or `backend-dir`) before listing evidence.
+  2. Keep evidence paths consistent with the selected mode.

--- a/backend/.agents/skills/scan-project-backend/templates/backend-project-architecture-template.md
+++ b/backend/.agents/skills/scan-project-backend/templates/backend-project-architecture-template.md
@@ -1,0 +1,79 @@
+# Backend Project Architecture Snapshot
+
+- Scan date: YYYY-MM-DD
+- Scope: `backend/`
+- Scanner: Codex (`scan-project-backend`)
+- Execution mode: `repo-root | backend-dir`
+- Evidence path base: `backend/... | ./...`
+
+## 1. Summary
+- Backend style classification: `Layered monolith | Domain-modular monolith | Microservices | Hybrid`
+- Confidence: `High | Medium | Low`
+- Notes:
+
+## 2. Confirmed facts
+- Build/runtime baseline:
+  - Evidence files:
+  - Evidence commands:
+- Package/layer map:
+  - Evidence files:
+  - Evidence commands:
+- API/security/i18n/response conventions:
+  - Evidence files:
+  - Evidence commands:
+
+## 3. Inferred facts
+- Inference:
+- Why inferred:
+- Evidence files:
+- Evidence commands:
+
+## 4. Unknowns (`REQUIRES CONFIRMATION`)
+- Item:
+- Why unknown:
+- How to verify:
+
+## 5. Command map (confirmed only)
+- Build:
+- Test:
+- Run:
+- Tooling:
+- Evidence files:
+
+## 5.1 Command execution notes
+- Successful commands:
+- Failed commands and reasons:
+- Unverified areas caused by command limitations:
+
+## 6. Risks and constraints
+- Contract/DB/security/dependency risks:
+- Operational risks:
+
+## 7. Backend pattern comparison (GitHub baselines)
+- Closest baseline:
+- Similarities:
+- Differences:
+- Potential implications:
+
+## 8. Convention compliance check
+- Maven standard layout: `Pass | Partial | Fail`
+  - Evidence:
+- Spring package/root scanning convention: `Pass | Partial | Fail`
+  - Evidence:
+- GitHub discoverability (README/docs/commands): `Pass | Partial | Fail`
+  - Evidence:
+
+## 9. How to update this snapshot
+1. Re-run backend scan steps from skill.
+2. Refresh changed sections only.
+3. Keep Confirmed/Inferred/Unknown separation strict.
+4. Update scan date.
+
+## 10. Citation format requirement
+- Use repository-relative file path citations when reporting scan results.
+- Recommended format: `【F:<path>†Lx-Ly】`.
+
+## 11. AI usability checklist
+- Keep headings unchanged for downstream parsing.
+- Keep status values deterministic: `Pass | Partial | Fail`.
+- Keep unknowns explicit with `REQUIRES CONFIRMATION`.


### PR DESCRIPTION
### Motivation
- Provide a reproducible, evidence-first backend-only scanner for the `backend/` subtree to generate an architecture snapshot and command map.
- Improve Codex skill efficiency and determinism by codifying progressive-disclosure and evidence budget rules for backend scans.
- Supply reference heuristics for classifying Java/Spring repo patterns and industry convention checks to reduce guesswork during scans.

### Description
- Add `backend/.agents/skills/scan-project-backend/SKILL.md` implementing the scan workflow, minimal evidence commands, outputs, and required artifact rules.
- Add reference guidance files `backend/.agents/skills/scan-project-backend/references/codex-skill-optimization.md`, `.../github-java-backend-patterns.md`, and `.../industry-conventions.md` to capture optimization rules, GitHub pattern baselines, and convention checks.
- Add `backend/.agents/skills/scan-project-backend/templates/backend-project-architecture-template.md` as the persistent artifact template for generated architecture snapshots.
- This change is documentation-only and does not modify production source code or build scripts.

### Testing
- No automated tests were added or run for this documentation-only change.
- Files were added as Markdown assets only and require downstream integration tests if executed by agent tooling.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69d43dfa9b2c83238998708b6862dd51)