### PR TITLE
強化 backend `review-change` SKILL.md 為可執行的審查指引

### DIFF
--- a/backend/.agents/skills/review-change/SKILL.md
+++ b/backend/.agents/skills/review-change/SKILL.md
@@ -1,34 +1,217 @@
 ---
 name: review-change
-description: Use to review backend changes for correctness, security, maintainability, and testing risk before delivery.
+description: Review backend-ready patches for correctness, security, maintainability, and testing risk, then provide evidence-based findings with severity and delivery recommendation.
 ---
 
 # review-change
 
+## Description
+A task-specific **backend code review** skill for evaluating a delivery-ready patch/diff.
+
+This skill is for assessment and decision support, not implementation.
+
 ## Purpose
-Perform structured code review with severity grading.
+- Produce structured, evidence-based review findings for backend changes.
+- Grade findings consistently (P0–P3) by impact and delivery risk.
+- Provide a clear delivery recommendation for PR / pre-merge / release gate flow.
+
+## What This Skill Does
+- Reviews changed backend code and directly impacted files.
+- Evaluates four dimensions: correctness, security, maintainability, testing risk.
+- Reports actionable findings with file/line evidence and fix direction.
+- Explicitly reports missing evidence and uncertainty.
+
+## What This Skill Does **Not** Do
+- Does **not** implement, refactor, or rewrite code as primary output.
+- Does **not** redesign architecture or rewrite requirements.
+- Does **not** request unrelated large-scale cleanup.
+- Does **not** convert style preference into high-severity defects.
+
+## When to Use
+Use this skill when:
+- A backend patch/diff is ready for review.
+- A PR is ready for pre-merge confidence check.
+- A delivery decision needs structured risk assessment.
+- Security/correctness confidence is required before ship.
+
+## When Not to Use
+Do **not** use this skill when:
+- Requirements are not defined enough to review correctness.
+- There is no concrete diff/changed file set.
+- The main task is implementation, refactor, scan, or architecture planning.
+- The requester expects code changes instead of review findings.
 
 ## Trigger Conditions
-- A backend patch is ready for review.
-- Security or correctness confidence is needed.
+Trigger this skill if at least one condition is true:
+1. User asks for backend review, PR review, readiness check, or delivery gate decision.
+2. Backend patch is marked “ready”, “PR ready”, or “before merge”.
+3. User asks for severity-based findings (P0–P3) with recommendation.
 
 ## Inputs
-- Diff/changed files
-- Backend rules and conventions
+Required inputs:
+- Patch/diff or changed file list.
+- Relevant backend conventions/rules (AGENTS.md, project rules, review rules).
 
-## Steps
-1. Check correctness against requirements.
-2. Check security-sensitive surfaces and error handling.
-3. Check maintainability and style consistency.
-4. Check validation sufficiency and regressions.
-5. Classify issues by severity (P0-P3).
+Strongly recommended inputs (ask if missing):
+- Task requirement and acceptance criteria.
+- Impacted scope/modules/endpoints.
+- Test evidence (unit/integration/e2e), CI status, failing/passing context.
+- Security-sensitive context (auth, permission, token, PII, external trust boundaries).
+- Known constraints, non-goals, intentional trade-offs.
 
-## Outputs
-- Review findings with file/line references
-- Delivery recommendation (ship / fix required)
+## Preconditions
+Before reviewing, confirm:
+1. Diff is accessible and readable.
+2. Review scope is defined (what changed / what not changed).
+3. Requirements are available or explicitly marked missing.
+
+If preconditions are not met, do not guess; continue with limited review and mark uncertainty explicitly.
+
+## Review Dimensions
+
+### 1) Correctness
+Check whether change behavior matches stated requirement and existing contracts.
+
+Review rules:
+- Map each meaningful code change to requirement/acceptance criteria.
+- Flag logic mismatches, missing updates, partial fixes, and broken invariants.
+- Check edge cases: null/empty, bounds, status transitions, time/date, concurrency/order, idempotency.
+- Check data flow: input → validation → domain logic → persistence → response.
+- Check contract consistency: DTO/schema/error code/response shape affected by this diff.
+
+If requirement evidence is missing, do not assert defect as fact; mark `REQUIRES CONFIRMATION`.
+
+### 2) Security
+Check for security regressions on changed paths and trust boundaries.
+
+Review rules:
+- Authentication/authorization: missing/bypassed checks, permission drift, privilege escalation.
+- Input validation: unsafe assumptions, insufficient validation, dangerous defaults.
+- Sensitive data handling: PII/token/secret leakage in logs, response, exception, telemetry.
+- Error handling: stack trace/internal detail exposure, security-relevant error leakage.
+- Injection/deserialization risks: SQL/JPQL/command/template/serialization misuse.
+- Trust boundary violations: untrusted input crossing into privileged operations.
+- Auditability gaps: critical actions missing audit/security event hooks when expected.
+
+If security impact is plausible but not provable from diff alone, mark `RISK NOT VERIFIED` with required evidence.
+
+### 3) Maintainability
+Report maintainability issues only when they add concrete future risk.
+
+Report when:
+- Change creates hidden coupling or unclear ownership.
+- Complex logic lacks structure/comments/tests enough to safely maintain.
+- Error handling or branching is duplicated/inconsistent in ways likely to diverge.
+- New behavior violates established backend layering/conventions, increasing bug risk.
+
+Do not report as findings:
+- Personal naming/style preference without measurable maintenance risk.
+- Pure formatting nits unless they block correctness/security/operability.
+
+### 4) Testing Risk & Validation Sufficiency
+Assess whether available verification is enough for change risk.
+
+Review rules:
+- Identify risk class of changed behavior: low/medium/high impact.
+- Check whether tests cover changed logic and key edge/error paths.
+- Verify CI/test evidence exists and matches touched scope.
+- Flag regression risk when high-risk changes lack targeted verification.
+- Escalate severity when high-impact path has no credible validation evidence.
+
+If test/CI evidence is missing, mark `INSUFFICIENT EVIDENCE` and specify required checks.
+
+## Review Steps (Execution Order)
+1. **Collect context**: diff, scope, requirements, constraints, rules.
+2. **Run correctness review** using explicit requirement mapping.
+3. **Run security review** on changed code and trust boundaries.
+4. **Run maintainability review** with anti-nitpick filter.
+5. **Assess testing/CI sufficiency** and regression risk.
+6. **Assign severity** using severity rules below.
+7. **Generate output contract** exactly (summary, findings, recommendation, unknowns).
+
+## Severity Rules (P0–P3)
+Use impact + exploitability + delivery risk, not tone.
+
+- **P0 – Critical / Stop-Ship**
+  - Likely severe security breach, data corruption/loss, or production outage.
+  - Immediate fix required before merge/release.
+
+- **P1 – High / Fix Required Before Delivery**
+  - High-confidence correctness or security defect with material user/business impact.
+  - Should block delivery until fixed or explicitly accepted by owner.
+
+- **P2 – Medium / Fix Soon (Can Ship With Explicit Acknowledgement)**
+  - Real risk exists but impact/scope is limited or conditional.
+  - Delivery possible only with documented risk acceptance and follow-up plan.
+
+- **P3 – Low / Improvement**
+  - Non-blocking issue with small impact; maintainability/clarity improvement.
+  - Track in backlog; should not block delivery.
+
+Severity assignment checklist (must be explicit per finding):
+- What fails?
+- Who/what is impacted?
+- Under what condition does it occur?
+- Why this severity now?
+
+## Output Contract
+Always return in this stable structure:
+
+1. **Review Summary**
+   - Scope reviewed.
+   - Overall risk statement.
+   - Count of findings by severity (P0/P1/P2/P3).
+
+2. **Findings (by severity, highest first)**
+   For each finding provide:
+   - `ID`
+   - `Severity`
+   - `Category` (Correctness/Security/Maintainability/Testing)
+   - `Evidence` (file + line or exact diff hunk)
+   - `Risk` (what can go wrong, impact)
+   - `Why this is a problem` (logic/rule basis)
+   - `Recommended fix direction` (actionable, no large unrelated redesign)
+   - `Confidence` (High/Medium/Low)
+   - `Evidence status` (Confirmed / INSUFFICIENT EVIDENCE / REQUIRES CONFIRMATION / RISK NOT VERIFIED)
+
+3. **Delivery Recommendation**
+   - One of: `SHIP`, `SHIP WITH ACKNOWLEDGED RISKS`, `FIX REQUIRED BEFORE SHIP`.
+   - Include reason tied to highest-severity findings.
+
+4. **Known Unknowns / Missing Evidence**
+   - List missing requirements, missing tests/CI, ambiguous intent, or out-of-scope risks.
+   - State exactly what evidence is needed to close each gap.
 
 ## Boundaries
-- Keep findings actionable and evidence-based.
+- Every finding must be evidence-based and traceable to changed code.
+- Do not present speculation as confirmed defect.
+- Do not demand unrelated broad refactor.
+- Do not infer correctness defects without requirement/contract basis.
+- Do not let style preference dominate review output.
+- Do not perform unauthorized code modifications as part of this skill.
 
 ## Verification
-- Ensure each finding maps to concrete code evidence.
+Before finalizing review output, verify:
+1. Every finding has concrete code evidence.
+2. Every severity has explicit rationale.
+3. Recommendation matches severity distribution.
+4. Missing evidence is explicitly labeled.
+5. Output is reusable in PR comments and delivery decision flow.
+
+## Failure / Uncertainty Handling
+Use these exact labels when evidence is incomplete:
+- `REQUIRES CONFIRMATION`: requirement/intent is unclear; cannot assert correctness conclusively.
+- `INSUFFICIENT EVIDENCE`: missing required artifacts (tests/CI/logs/design context).
+- `RISK NOT VERIFIED`: risk suspected but cannot be validated from available diff/context.
+
+When any label appears:
+- State what is unknown.
+- State why it blocks certainty.
+- State minimal evidence needed to resolve it.
+
+## What Not to Do
+- Do not rewrite requirements to create review findings.
+- Do not convert this review skill into implementation instructions.
+- Do not over-index on style nits.
+- Do not hide uncertainty.
+- Do not issue delivery recommendation without referencing evidence and severity.


### PR DESCRIPTION
### Motivation
- 將原本過於簡短的 `review-change` skill 文件補足為可執行、可驗證的後端 PR review 工作簿，以提升一致性與可追溯性。 
- 防止 scope‑creep 與主觀 nitpick，並讓 review 結果能直接用於 PR / pre-merge / delivery decision。 
- 補強 correctness/security/testing/maintainability 的可操作檢核規則與嚴重度判準，讓自動化 agent 或人工 reviewer 都能穩定產出 evidence-driven findings。

### Description
- 新增/重構章節：`Description`、`What This Skill Does`、`What This Skill Does Not Do`、`When to Use`、`When Not to Use`、`Trigger Conditions`、`Inputs`、`Preconditions`。 
- 為四大 review 維度（Correctness / Security / Maintainability / Testing Risk）加入具體檢查規則與判斷準則（例如邊界條件、資料流、授權、注入風險、測試覆蓋判準等）。
- 定義可執行的 `Review Steps`（收集上下文 → correctness → security → maintainability → testing → 指派 severity → 產出結構化報告）。
- 建立明確 severity 規則（P0–P3）與每項 finding 的輸出合約（ID、Severity、Category、Evidence、Risk、Why、Fix direction、Confidence、Evidence status），並加入三種不確定性標籤：`REQUIRES CONFIRMATION`、`INSUFFICIENT EVIDENCE`、`RISK NOT VERIFIED`。
- 強化邊界與驗證要求，明確禁止將 review 攘為非授權之 code 修改、廣泛重構或以 style nit 為高嚴重度缺陷。
- 檔案變更：`backend/.agents/skills/review-change/SKILL.md`（完整覆寫/擴充內容）。

### Testing
- 已讀取並驗證檔案內容與章節結構：`cat backend/.agents/skills/review-change/SKILL.md` (成功)、`nl -ba backend/.agents/skills/review-change/SKILL.md` (成功)、`rg --files .agents` / `find ... -name SKILL.md` (成功)。
- 變更僅為文件/skill 指引，無 runtime 程式碼或行為改動，因此未執行單元或整體後端測試（不適用）。
- 結果：文檔內容已按要求擴充並可直接貼回 skill 檔案以供後續使用。 
- Remaining risk / follow-up：建議用一個實際 backend diff 做一次示範 review 以檢驗輸出格式與可操作性，並在實務運作中微調 severity/wording（屬流程驗證，不是功能性風險）。

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69d488888c748323a99958573fa8da7e)