### PR TITLE
Enhance create-prd skill: make backend PRD drafting executable & verifiable

### DIFF
--- a/backend/.agents/skills/create-prd/SKILL.md
+++ b/backend/.agents/skills/create-prd/SKILL.md
@@ -1,38 +1,211 @@
 ---
 name: create-prd
-description: Use when backend requirements are ambiguous or a new backend feature is proposed; convert intent into a structured, testable PRD with explicit scope, API/data impact, and risks.
+description: Use this skill when backend requirements are ambiguous before implementation. Convert user intent into a structured, testable backend PRD with explicit scope, non-goals, API/data/auth impact, assumptions, risks, and open questions.
 ---
 
 # create-prd
 
+## Description
+A requirement-clarification skill for backend work. It turns ambiguous requests into a reusable backend PRD draft that implementation, review, and testing can execute against.
+
 ## Purpose
-Turn ambiguous backend requirements into executable product requirements before implementation.
+- Clarify backend problem statements before coding starts.
+- Separate confirmed requirements from assumptions and speculative ideas.
+- Produce a PRD draft with explicit scope, boundaries, and testable acceptance criteria.
+- Surface unknowns and high-risk impacts early (`REQUIRES CONFIRMATION`).
+
+## Role
+This skill **is**:
+- PRD drafting
+- requirement clarification
+- scope and risk definition
+
+This skill **is not**:
+- implementation
+- refactor planning
+- code review
+- architecture redesign
+
+## When to Use
+Use when at least one of these is true:
+- New backend feature request with incomplete details.
+- Large backend change spans multiple modules or layers.
+- API behavior, data behavior, or authorization behavior is unclear.
+- Acceptance criteria are missing, vague, or not testable.
+- Stakeholders disagree on expected backend outcomes.
+
+## When Not to Use
+Do not use when:
+- Requirements are already explicit and implementation-ready.
+- Task is a small bugfix with clear expected behavior.
+- Task is pure refactor/review with no requirement ambiguity.
+- You only need architecture scanning (`scan-project-backend`) or implementation planning (`plan-work`).
 
 ## Trigger Conditions
-- New backend feature request
-- Large backend change with unclear acceptance criteria
-- API/data behavior needs clear definition before coding
+Trigger this skill if request text includes signals like:
+- "需求還不清楚", "先整理需求", "先寫 PRD"
+- "新功能", "跨模組", "先定義 API/data 行為"
+- "驗收標準不明確", "先釐清 scope / non-goals"
 
-## Inputs
-- User goals
-- Backend constraints from `AGENTS.md` and `backend/AGENTS.md`
-- Existing backend architecture/context from scans or docs
+## Required Inputs
+Collect these inputs before drafting:
+1. **User intent and business outcome**
+   - User goal, expected value, target actor/stakeholder.
+2. **Repository rules and constraints**
+   - `AGENTS.md`
+   - `backend/AGENTS.md`
+3. **Backend architecture context**
+   - `backend/docs/backend-project-architecture.md` (preferred architecture snapshot)
+   - Relevant module/package files if request is module-specific.
+4. **Existing contract/constraint context** (if available)
+   - Current API/DTO behavior
+   - DB/schema/migration constraints
+   - Validation, auth, audit, permission constraints
+5. **Known limits and non-goals**
+   - Explicit exclusions from user/stakeholder.
 
-## Steps
-1. Define problem statement and desired backend outcomes.
-2. Specify scope, non-goals, and affected backend boundaries (Controller/Service/Repository).
-3. List user scenarios, API behaviors, and testable acceptance criteria.
-4. Capture assumptions, dependencies, risks, and escalation points requiring confirmation.
+If any required input is missing, continue with PRD drafting but explicitly mark unknown parts using:
+- `OPEN QUESTION`
+- `ASSUMPTION`
+- `REQUIRES CONFIRMATION`
 
-## Outputs
-- Structured backend PRD draft
-- Open questions requiring confirmation
+## Discovery Rules
+Before writing final PRD sections, run this sequence:
+1. **Normalize request**
+   - Rewrite user request into one-sentence problem statement.
+2. **Separate requirement types**
+   - Label each key statement as `PROBLEM`, `OUTCOME`, or `PROPOSED SOLUTION`.
+   - Do not treat `PROPOSED SOLUTION` as confirmed requirement by default.
+3. **Detect ambiguity**
+   - Find missing actor, trigger, input, output, error behavior, and constraints.
+4. **Detect conflicts**
+   - Check for contradictions between user intent, existing constraints, and architecture snapshot.
+5. **Classify uncertainty**
+   - Unknown but plausible = `ASSUMPTION`
+   - External dependency not controlled here = `DEPENDENCY`
+   - Potential negative impact = `RISK`
+   - Cannot proceed safely without answer = `REQUIRES CONFIRMATION`
+
+## Scope Rules
+Define clear boundaries in PRD:
+- `In Scope`: exact behaviors/outcomes delivered by this PRD.
+- `Out of Scope`: explicitly excluded behaviors and adjacent requests.
+- `Affected Boundaries`:
+  - Controller/API boundary
+  - Service/business boundary
+  - Repository/data access boundary
+  - External integration boundary
+
+Anti-scope-creep rules:
+- Every in-scope item must map to at least one acceptance criterion.
+- Any item without acceptance criteria must be moved to `OPEN QUESTION` or `OUT OF SCOPE`.
+- Do not add architecture redesign goals unless user explicitly requests them.
+
+## PRD Sections (Output Structure)
+Output must include all sections below in this order:
+1. `Summary`
+2. `Problem Statement`
+3. `Desired Backend Outcomes`
+4. `Scope (In Scope)`
+5. `Non-Goals (Out of Scope)`
+6. `Affected Backend Boundaries`
+7. `User Scenarios`
+8. `API Behavior Definition`
+9. `Data / Schema Impact`
+10. `Validation / Auth / Permission / Audit Impact`
+11. `Acceptance Criteria (Testable)`
+12. `Assumptions`
+13. `Dependencies`
+14. `Risks`
+15. `Open Questions`
+16. `Requires Confirmation`
+
+## API / Data / Auth Impact Rules
+For each impact section, explicitly label status:
+- `Confirmed`
+- `Potential`
+- `Unknown`
+
+Mandatory checks:
+- API contract impact: endpoint, request/response shape, status/error behavior, backward compatibility.
+- Data impact: entity/table/schema/index/migration expectation, write/read path impact.
+- Validation impact: input rules, field constraints, error signaling.
+- Auth/permission impact: who can call, role/policy checks, token/session expectations.
+- Audit/logging impact: whether action must be traceable.
+
+If breaking change is possible and unconfirmed, add to `REQUIRES CONFIRMATION`.
+
+## Acceptance Criteria Rules
+Each acceptance criterion must be:
+- Observable (can be checked via API response, DB state, log/event, or explicit output).
+- Deterministic (clear expected result).
+- Bounded (clear precondition and trigger).
+- Testable (maps to at least one test idea).
+
+Format each criterion as:
+- `AC-<id>`
+- `Given` (precondition)
+- `When` (action/trigger)
+- `Then` (expected result)
+
+Coverage minimum:
+- Success path
+- Failure path
+- Validation failure
+- Authorization/permission behavior (if endpoint is protected)
+- At least one edge case
+
+Reject criteria that are vague (example of invalid wording: "system should work correctly").
+
+## Assumptions / Risks / Open Questions Handling
+Use strict definitions:
+- `ASSUMPTION`: temporary working statement used due to missing confirmation.
+- `DEPENDENCY`: external team/system/policy/date needed to deliver outcome.
+- `RISK`: uncertainty that may cause failure, delay, security issue, or contract break.
+- `OPEN QUESTION`: question that improves PRD quality but does not fully block drafting.
+- `REQUIRES CONFIRMATION`: blocker or high-risk item that must be answered before safe implementation.
+- `OUT OF SCOPE`: explicitly not delivered in this PRD.
+
+Do not hide uncertainty inside narrative text; list it in explicit sections.
+
+## Output Contract
+The final PRD draft must:
+- Follow all section headings from `PRD Sections`.
+- Use explicit labels for unknown/high-risk items.
+- Include testable acceptance criteria IDs (`AC-001`, `AC-002`, ...).
+- Be implementation-ready at requirement level, without implementation design details.
+- Be reusable by downstream skills (`plan-work`, implementation, review, test verification).
 
 ## Boundaries
-- Do not jump into implementation details when requirements are still unclear.
-- Do not propose breaking API/schema/security changes without explicitly flagging confirmation needs.
+- Do not write code.
+- Do not provide low-level implementation design unless user explicitly asks in a separate task.
+- Do not convert unverified assumptions into confirmed facts.
+- Do not smuggle architecture redesign into requirement text.
+- Do not propose API/schema/security breaking changes without `REQUIRES CONFIRMATION`.
+- Do not ignore repository constraints in `AGENTS.md`, `backend/AGENTS.md`, and architecture snapshot.
 
-## Verification
-- Ensure acceptance criteria are testable.
-- Ensure assumptions and risks are clearly marked.
-- Ensure backend layering and validation expectations are reflected in the PRD.
+## Verification Checklist
+Before finalizing PRD, verify:
+1. Scope/non-goals do not conflict.
+2. Each in-scope item maps to scenario + acceptance criteria.
+3. Acceptance criteria are testable and cover success/failure/validation/auth/edge cases.
+4. API/data/auth impacts are explicitly marked (`Confirmed/Potential/Unknown`).
+5. Unknowns are surfaced in `Open Questions` or `Requires Confirmation`.
+6. No unconfirmed breaking change is presented as decided.
+7. PRD stays at requirement level (not implementation planning).
+
+## Failure / Uncertainty Handling
+If information is insufficient:
+1. Continue with best-effort PRD draft.
+2. Mark every unknown using required labels.
+3. Add focused follow-up questions under `Open Questions`.
+4. Promote blockers/high-risk unknowns to `Requires Confirmation`.
+5. State what cannot be validated from current repository evidence.
+
+## What Not to Do
+- Do not skip problem clarification and jump to solution details.
+- Do not collapse scope/non-goals into a single vague paragraph.
+- Do not output acceptance criteria without measurable expected results.
+- Do not omit API/data/auth impact analysis.
+- Do not hide major risks behind generic wording.
+- Do not treat this skill as implementation planning or code task execution.


### PR DESCRIPTION
### Motivation
- 提升 `create-prd` skill 的可執行性與可驗證性，讓它能在 ambiguous backend requirements 情境下產出可供實作/測試/審查直接使用的 PRD。 
- 明確界定此 skill 的角色邊界（PRD/需求澄清，不做實作或重構），並強制把未知與高風險項目標示成 `REQUIRES CONFIRMATION` 等分類。 
- 補強輸入契約、發現流程、scope 規則、API/data/auth 影響分析、以及可測試的 acceptance criteria 格式，減少下游實作與測試不確定性。

### Description
- 完整重寫並擴充 `backend/.agents/skills/create-prd/SKILL.md`，新增並明確化：`Description`、`Role`、`When to Use`/`When Not to Use`、`Trigger Conditions`、`Required Inputs`、`Discovery Rules`、`Scope Rules`、`PRD Sections`、`API / Data / Auth Impact Rules`、`Acceptance Criteria Rules`、`Assumptions/Dependencies/Risks/Open Questions Handling`、`Output Contract`、`Verification Checklist`、`Failure / Uncertainty Handling`、`What Not to Do`。 
- 強制 acceptance criteria 格式為 `AC-<id>` + `Given/When/Then`，並要求涵蓋 success/failure/validation/auth/edge case。 
- API/data/auth 影響分析加入狀態標示（`Confirmed`/`Potential`/`Unknown`）與明確檢查項目（endpoint、request/response、schema/migration、auth、audit 等）。 
- 在 skill 內指定 `backend/docs/backend-project-architecture.md` 為首選架構快照來源以支持發現步驟；保留 `backend/AGENTS.md` 作為 durable constraints 參考。 
- 檔案已 commit（commit id: `ce08a40`）且 PR 建立資訊已產生（PR 標題與說明由工具生成）。

### Testing
- 已執行並成功的檢查/命令：`pwd`、`rg --files`、`find . -path '*/create-prd/SKILL.md'`、`cat AGENTS.md`、`cat backend/AGENTS.md`、`cat backend/.agents/skills/create-prd/SKILL.md`、`cat backend/docs/backend-project-architecture.md`、`git status`、`git diff -- backend/.agents/skills/create-prd/SKILL.md`、寫入新 `SKILL.md`、`git commit`（結果：1 file changed, commit `ce08a40`），以及列印檔案內容（`nl -ba ...`）；上述命令均成功。 
- 沒有執行任何後端建置或單元/整合測試（未跑 `./mvnw test` / `./mvnw clean install`），因為本次變更僅為 docs/skill 說明。 
- 未驗證的項目/風險：未透過後端測試驗證任何行為變更（因無程式碼變更），若後續 PRD 指向需要 schema/contract 更改，需先把那些項目標為 `REQUIRES CONFIRMATION` 並在變更前執行 `./mvnw test` 或相關驗證。

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69d48ec9d9188323a6c33e8560e0e21c)