### PR TITLE
Upgrade scan-project to full-repo monorepo scan + architecture template

### DIFF
--- a/.agents/skills/scan-project/SKILL.md
+++ b/.agents/skills/scan-project/SKILL.md
@@ -1,79 +1,146 @@
 ---
 name: scan-project
-description: Use when entering an unfamiliar repo or before generating/updating AGENTS.md and skills; map real structure, commands, and constraints without guessing, then produce a reusable architecture snapshot for future agent guidance.
+description: Use when entering an unfamiliar repo or before generating/updating AGENTS.md and skills; scan the full repository (monorepo-safe), map real structure/commands/constraints without guessing, and produce a reusable architecture snapshot for future agent workflows.
 ---
 
 # scan-project
 
 ## Purpose
-Produce a factual, reproducible project scan that supports planning, AGENTS.md updates, and future onboarding.
+Produce a factual, reproducible, full-repo architecture and governance snapshot for monorepo/full-stack projects.
 
-## Why this design
-- Keep docs close to code and maintain them in version control (GitHub repository documentation guidance).
-- Use lightweight architecture documentation that teams can actually maintain (arc42 + C4 model).
-- Capture important trade-off decisions as ADR links when present.
+This skill is for **scanning and documenting**. It is **not** an implementation, review, refactor, or migration skill.
 
-## Trigger Conditions
+## When to Use
 - First task in an unfamiliar repository.
-- Before creating/updating `AGENTS.md` or any `SKILL.md`.
-- Before proposing broad refactors across modules.
+- Before creating/updating `AGENTS.md`.
+- Before creating/updating any `SKILL.md`.
+- Before planning multi-module work (frontend/backend/shared/infra/docs).
 
 ## Inputs
-- User request and current goal
-- Existing repository files
-- Existing architecture docs (`docs/`, `README*`, ADR folders, diagrams)
+- User request and stated scope.
+- Repository files at current commit.
+- Existing docs (`README*`, `docs/`, ADRs, module docs).
+- Governance files (`AGENTS.md` and nested overrides).
 
-## Steps
-1. **Scan structure (facts only)**
-   - List top-level directories and identify code modules.
-   - Detect major manifests/build files and infer toolchain from those files only.
-2. **Detect governance and scope rules**
-   - Find all `AGENTS.md` files.
-   - Build scope precedence map (root to nested overrides).
-3. **Extract runnable commands from evidence**
-   - Read scripts/wrappers/manifests to collect build/test/lint/run commands.
-   - Mark unknowns as `REQUIRES CONFIRMATION` instead of guessing.
-4. **Summarize architecture at practical depth**
-   - Identify system context, main containers/apps, key components, and data boundaries.
-   - Link each architecture claim to specific files.
-5. **Generate architecture snapshot document**
-   - Create or update `docs/project-architecture.md` using the template in `templates/project-architecture-template.md`.
-   - Ensure this file is concise and usable as input for future `AGENTS.md` maintenance.
-6. **Report confidence and gaps**
-   - Separate confirmed facts vs assumptions.
-   - Add unknowns and validation follow-ups.
+## Required Scan Scope (Root-Level First)
+Always start at repository root. Do not assume backend-only structure.
+
+Minimum topology to check (if present):
+- `backend/`
+- `frontend/`
+- `src/`
+- `docs/`
+- `.agents/`
+- root `AGENTS.md`
+- root `README*`
+
+Also detect additional module roots (examples):
+- `apps/`, `packages/`, `services/`, `libs/`, `workers/`, `infra/`, `deploy/`, `scripts/`
+
+## Workflow (Ordered, Do Not Skip)
+1. **Scan top-level topology (facts only)**
+   - List top-level directories/files.
+   - Identify candidate modules/apps/packages/deployables.
+   - Record evidence paths for each detection.
+
+2. **Build governance map (`AGENTS.md` precedence)**
+   - Find root and nested `AGENTS.md` files.
+   - Map scope tree: root rules → nested overrides.
+   - Record which directories each governance file controls.
+
+3. **Detect manifests and wrappers (root + module-level)**
+   - Root: build/workspace/CI manifests and scripts.
+   - Module-level: local manifests, wrappers, tool configs.
+   - Do not infer framework/runtime unless a file proves it.
+
+4. **Extract runnable commands from evidence**
+   - Build a command inventory grouped by scope:
+     - `root`
+     - `frontend`
+     - `backend`
+     - `shared`
+     - `infra/docs/other module`
+   - Allowed command sources:
+     - Manifests (`package.json`, `pom.xml`, `build.gradle*`, `Makefile`, etc.)
+     - Wrapper scripts (`mvnw`, `gradlew`, shell scripts, task runners)
+     - CI/workflow files
+     - Explicit project docs (`README`, module docs, AGENTS guidance)
+   - If not evidenced, mark `REQUIRES CONFIRMATION`.
+
+5. **Map architecture surfaces (confirmed vs inferred vs unknown)**
+   - System context (actors, external systems, high-level purpose).
+   - Frontend apps, backend services, shared modules/packages.
+   - Datastores, messaging, third-party integrations.
+   - Deployment boundaries and runtime ownership boundaries.
+   - Every claim must carry status:
+     - `Confirmed` (direct evidence exists)
+     - `Inferred` (reasonable but indirect)
+     - `Unknown / REQUIRES CONFIRMATION`
+
+6. **Generate/update persistent snapshot**
+   - Create or update `docs/project-architecture.md`.
+   - Use `templates/project-architecture-template.md` headings exactly.
+   - Keep output concise, evidence-linked, and reusable by other skills.
+
+7. **Final consistency checks**
+   - Module map consistency: topology ↔ deployables table ↔ commands scope.
+   - Governance consistency: AGENTS scope map ↔ rules summary.
+   - Evidence consistency: each key claim has source paths.
+   - Unknown handling: unresolved items listed as `REQUIRES CONFIRMATION`.
+
+## Command Collection Rules (Strict)
+- Never invent commands.
+- Never promote common framework defaults to facts without evidence.
+- Keep command rows separate by scope and source.
+- If root and module docs conflict, record conflict explicitly in unknowns.
 
 ## Required Outputs
-1. **Scan summary in response**
-   - Directory/module summary
-   - AGENTS scope hierarchy
-   - Confirmed commands
-   - Constraints and risks
-   - `REQUIRES CONFIRMATION` list
-2. **Persistent artifact**
-   - `docs/project-architecture.md` (new or updated)
+1. **Chat summary (short, structured)**
+   - Topology/module map.
+   - Governance precedence map.
+   - Confirmed commands by scope.
+   - Architecture highlights (with status labels).
+   - Risks/unknowns and `REQUIRES CONFIRMATION` list.
 
-## `docs/project-architecture.md` quality bar
-- Must include exact date (`YYYY-MM-DD`) and scan scope.
-- Must cite concrete file paths for key claims.
-- Must distinguish:
-  - Confirmed
-  - Inferred
-  - Unknown / `REQUIRES CONFIRMATION`
-- Must include a "How to update" section so future agents can refresh quickly.
+2. **Persistent artifact**
+   - `docs/project-architecture.md` updated using the template.
+
+## `docs/project-architecture.md` Quality Bar
+Must include all of the following:
+- Exact scan date (`YYYY-MM-DD`).
+- Scan scope (`full repo` or explicit sub-scope).
+- Source commit SHA.
+- Stable section headings from template (no ad-hoc renaming).
+- Clear status labeling (`Confirmed` / `Inferred` / `Unknown`).
+- Evidence file paths for key claims.
+- Root + module command inventory with source paths.
+- Governance precedence map (root + nested AGENTS).
+- Explicit unknowns and confirmation actions.
+- "How to Update" steps that remove stale facts.
 
 ## Boundaries
-- Never fabricate commands, ownership, architecture, or dependencies.
-- Prefer shortest accurate scan first; deepen only where task requires.
-- Do not edit unrelated docs while generating the architecture snapshot.
+- Do not convert this skill into implementation/review/refactor work.
+- Do not edit unrelated documents while producing snapshot.
+- Do not guess framework, deployment topology, ownership, or dependencies.
+- Do not write inferred statements as confirmed facts.
 
-## Verification
-- Re-check every cited file path exists.
-- Re-run minimal commands used for evidence collection when output is ambiguous.
-- Confirm `docs/project-architecture.md` is internally consistent with the scan summary.
+## Uncertainty Handling
+When evidence is missing or conflicting:
+- Mark item `Unknown / REQUIRES CONFIRMATION`.
+- State why evidence is insufficient or conflicting.
+- Provide one concrete confirmation method (file, command, owner, or doc).
 
-## External references used by this skill design
-- GitHub Docs, repository documentation best practices: https://docs.github.com/en/repositories/creating-and-managing-repositories/best-practices-for-repositories
-- arc42 template overview: https://arc42.org/
-- C4 model (official): https://c4model.com/
-- ADR hub and rationale references: https://adr.github.io/
+## Verification Checklist (Before Handoff)
+- [ ] Top-level topology captured from root.
+- [ ] Frontend/backend/shared/docs/infra surfaces assessed.
+- [ ] AGENTS root-to-nested precedence documented.
+- [ ] Commands grouped by scope with source evidence.
+- [ ] Architecture claims labeled Confirmed/Inferred/Unknown.
+- [ ] Unknowns + confirmation methods listed.
+- [ ] `docs/project-architecture.md` internally consistent and reusable.
+
+## Design References
+- GitHub Docs (repository documentation best practices): https://docs.github.com/en/repositories/creating-and-managing-repositories/best-practices-for-repositories
+- arc42 (architecture documentation template): https://arc42.org/
+- C4 model (software architecture visual abstraction): https://c4model.com/
+- ADR practices and references: https://adr.github.io/

--- a/.agents/skills/scan-project/templates/project-architecture-template.md
+++ b/.agents/skills/scan-project/templates/project-architecture-template.md
@@ -4,60 +4,115 @@
 - Repository: <repo-name>
 - Scan scope: <full repo | subdirectory>
 - Source commit: <git sha>
+- Scanner: <agent/version>
 
-## 1) System Context (Confirmed)
+## 1) Scan Scope and Evidence Policy
+- Scope included:
+- Scope excluded:
+- Evidence policy:
+  - `Confirmed` = directly supported by repository evidence.
+  - `Inferred` = plausible from partial evidence; not yet directly proven.
+  - `Unknown / REQUIRES CONFIRMATION` = missing or conflicting evidence.
+- Primary evidence files:
+
+## 2) Repository Topology and Module Map
+
+### 2.1 Top-level directory map (Confirmed)
+| Path | Type | Role | Status | Evidence |
+|---|---|---|---|---|
+| backend/ | module | backend service(s) | Confirmed | <path> |
+| frontend/ | module | frontend app(s) | Confirmed | <path> |
+| docs/ | docs | product/technical docs | Confirmed | <path> |
+| .agents/ | governance | agent skills/rules | Confirmed | <path> |
+
+### 2.2 Module/package inventory (Confirmed + Inferred)
+| Unit | Kind (app/service/package/worker/docs/infra) | Path | Depends on | Deployable | Status | Evidence |
+|---|---|---|---|---|---|---|
+| <unit-name> | <kind> | <path> | <deps or unknown> | <yes/no/unknown> | <Confirmed/Inferred/Unknown> | <path> |
+
+## 3) System Context and Runtime Boundaries
+
+### 3.1 System context (Confirmed)
 - Product/domain objective:
 - Primary users/actors:
 - External systems/services:
 - Evidence:
 
-## 2) Containers / Deployable Units (Confirmed)
-| Container | Path | Runtime/Framework | Responsibility |
+### 3.2 Runtime/deployment boundaries (Confirmed + Inferred)
+- Frontend runtime boundary:
+- Backend runtime boundary:
+- Worker/batch/runtime boundary:
+- Infra/deploy boundary:
+- Status + evidence for each boundary:
+
+## 4) Applications / Services / Packages / Deployable Units
+| Unit | Path | Runtime/Framework | Responsibility | Interfaces (API/UI/Event) | Data stores | Third-party integrations | Deploy target | Status | Evidence |
+|---|---|---|---|---|---|---|---|---|---|
+| <frontend-app> | <path> | <runtime or unknown> | <summary> | <summary> | <summary> | <summary> | <summary> | <Confirmed/Inferred/Unknown> | <path> |
+| <backend-service> | <path> | <runtime or unknown> | <summary> | <summary> | <summary> | <summary> | <summary> | <Confirmed/Inferred/Unknown> | <path> |
+| <shared-package> | <path> | <runtime or unknown> | <summary> | <summary> | n/a | <summary> | n/a | <Confirmed/Inferred/Unknown> | <path> |
+
+## 5) Interaction and Data Boundaries
+
+### 5.1 Frontend ↔ Backend interactions
+| From | To | Interface | Contract location | Auth boundary | Status | Evidence |
+|---|---|---|---|---|---|---|
+| <frontend> | <backend> | <REST/GraphQL/RPC/Event/unknown> | <path/unknown> | <boundary/unknown> | <Confirmed/Inferred/Unknown> | <path> |
+
+### 5.2 Backend ↔ Data stores / third-party
+| From | To | Interface | Secrets/config path | Failure boundary | Status | Evidence |
+|---|---|---|---|---|---|---|
+| <backend> | <db/queue/external api> | <driver/protocol> | <path/unknown> | <summary/unknown> | <Confirmed/Inferred/Unknown> | <path> |
+
+### 5.3 Config, secrets, and environment boundaries
+- Config entry points (root + module-level):
+- Secrets handling locations:
+- Environment split (dev/stage/prod) evidence:
+- Unknowns:
+
+## 6) Commands Inventory (Evidence-based)
+
+### 6.1 Confirmed runnable commands
+| Scope (root/frontend/backend/shared/infra/docs) | Purpose | Command | Working directory | Source file/path | Status |
+|---|---|---|---|---|---|
+| root | <build/test/lint/run/etc> | <command> | <dir> | <path> | Confirmed |
+
+### 6.2 Unknown or conflicting commands (`REQUIRES CONFIRMATION`)
+| Scope | Candidate command | Why unknown/conflicting | How to confirm |
 |---|---|---|---|
-| example-backend | backend/ | Spring Boot | API + domain services |
+| <scope> | <command> | <reason> | <file/owner/command> |
 
-## 3) Component View (Confirmed + Inferred)
-### 3.1 Confirmed components
-- Component:
-  - Path:
-  - Responsibility:
-  - Depends on:
-  - Evidence:
+## 7) Governance Map (AGENTS and Local Rules)
 
-### 3.2 Inferred components (mark clearly)
-- Inference:
-  - Why inferred:
-  - What to verify:
+### 7.1 AGENTS precedence chain
+1. `<path>` controls `<scope>`
+2. `<path>` overrides `<parent path>` for `<scope>`
 
-## 4) Data and Integration Boundaries
-- Datastores:
-- Message/event integrations:
-- Third-party APIs:
-- Secrets/config boundaries:
-- Evidence:
+### 7.2 Additional governance artifacts
+| Artifact | Scope | Purpose | Status | Evidence |
+|---|---|---|---|---|
+| <docs/template/skill/policy> | <scope> | <purpose> | <Confirmed/Inferred/Unknown> | <path> |
 
-## 5) Build / Test / Run Commands (Confirmed)
-| Purpose | Command | Source file/path |
-|---|---|---|
-| test | ./mvnw test | backend/AGENTS.md |
+### 7.3 Practical implications for future agents
+- Durable rules to keep in AGENTS (root-level + module-level):
+- Workflow/procedure content better kept in skills:
 
-## 6) Agent Governance Map
-- AGENTS precedence chain:
-  1.
-  2.
-- Additional local rules (if any):
+## 8) Risks, Unknowns, and Confirmation Plan
+| Area | Unknown / risk | Impact | Required confirmation action | Owner/source |
+|---|---|---|---|---|
+| <module> | <unknown> | <impact> | <next step> | <file/person/team> |
 
-## 7) Risks / Unknowns / REQUIRES CONFIRMATION
-- Unknown:
-  - Why unknown:
-  - How to confirm:
+## 9) Suggested Inputs for Next Workflows
+- For AGENTS updates:
+- For skills updates:
+- For PRD/planning:
+- For implementation/review handoff:
 
-## 8) Suggested `AGENTS.md` Implications
-- Durable rules worth keeping in AGENTS:
-- Workflow details better kept in skills:
-
-## 9) How to Update This Snapshot
-1. Re-run scan-project.
-2. Refresh module map and command table from manifests/scripts.
-3. Update evidence links and unknowns.
-4. Keep only currently true facts; remove stale statements.
+## 10) How to Update This Snapshot
+1. Re-scan from repository root (topology first, then governance, then manifests/commands).
+2. Refresh module inventory and deployable units table.
+3. Refresh command inventory by scope from direct evidence only.
+4. Reconcile root and module-level governance precedence.
+5. Relabel each changed claim as Confirmed/Inferred/Unknown.
+6. Remove stale facts that no longer have evidence.
+7. Update unknowns with concrete `REQUIRES CONFIRMATION` actions.


### PR DESCRIPTION
### Motivation
- 把原先偏向 backend 的 root scan 升級為真正的 full-repo / monorepo-aware 工具，讓 root-level scan 可正確覆蓋 frontend、backend、shared、infra、docs 等面向。 
- 強化 evidence-driven 原則與不確定性處理，以避免把推測當作事實輸出，並使後續 AGENTS/skills/PRD/implementation 能穩定重用掃描結果。 
- 提供穩定且可重複的 architecture snapshot 模板，支援 module-level 命令與治理（AGENTS）繼承/覆寫地圖，方便後續自動化或人工驗證。 

### Description
- 將 `.agents/skills/scan-project/SKILL.md` 重寫為 root-first、monorepo-safe 的掃描工作流程，新增有序步驟：topology → governance → manifests/wrappers → commands by scope → architecture surfaces → snapshot generation → 一致性檢查。 
- 修改與擴充 `.agents/skills/scan-project/templates/project-architecture-template.md`，加入 repo topology/module map、frontend↔backend 互動表、scope-based commands table、governance artifacts、module-level risks 與穩定 section 名稱。 
- 加入嚴格規則：所有重要主張必須標記狀態 (`Confirmed` / `Inferred` / `Unknown / REQUIRES CONFIRMATION`)、只從 manifest/scripts/CI/docs 提取命令、若衝突或缺證據則標示 `REQUIRES CONFIRMATION`，並新增驗證清單與更新流程。 
- 變更檔案（僅文件/skills 層面）：
  - `.agents/skills/scan-project/SKILL.md`（重寫並擴充）
  - `.agents/skills/scan-project/templates/project-architecture-template.md`（替換為 full-stack 通用模板）

### Testing
- 檢視/驗證命令：執行 `rg --files -g 'AGENTS.md'` 以確認治理檔案位置，執行結果成功並回傳 root 與 backend 的 `AGENTS.md`。 (成功)
- 檔案內容檢查：使用 `sed` 與 `nl` 閱讀並比對兩個修改後的 markdown 檔案以確認結構與節點，檢查過程中無解析錯誤且內容符合預期模板格式。 (成功)
- 差異與格式檢查：執行 `git diff -- .agents/skills/scan-project/SKILL.md .agents/skills/scan-project/templates/project-architecture-template.md` 與 `git diff --check` 以確認無衝突或語法警告，結果顯示修改一致且未產生 diff-check 問題。 (成功)

Files changed: `.agents/skills/scan-project/SKILL.md`, `.agents/skills/scan-project/templates/project-architecture-template.md`.
Commands run (selected): `rg --files -g 'AGENTS.md'`, `sed -n '...' .agents/skills/scan-project/SKILL.md`, `sed -n '...' .agents/skills/scan-project/templates/project-architecture-template.md`, `git diff -- .agents/skills/scan-project/SKILL.md .agents/skills/scan-project/templates/project-architecture-template.md`, `git diff --check`, `nl -ba ...`.
Results: all automated checks listed above completed without errors.

Remaining risks / recommended follow-ups (not executed here):
- 用新 skill 實際執行一次 end-to-end scan，並產出 `docs/project-architecture.md` 以驗證模板可產生實務可用的 snapshot。 
- 若 repository 未來新增特殊模組（例如 `mobile/`、`data/`），建議把其加入 skill 的 module roots examples 列表以保持覆蓋完整性。

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69d49307879c8323b8fc8e8d20715a3d)