### PR TITLE
Improve root-level verify-change skill with explicit verification contract

### DIFF
--- a/.agents/skills/verify-change/SKILL.md
+++ b/.agents/skills/verify-change/SKILL.md
@@ -1,33 +1,193 @@
 ---
 name: verify-change
-description: Use for high-level verification of documentation or small-scope changes to confirm completeness, consistency, and unresolved risks.
+description: Root-level lightweight verification for docs/config/rules/templates/AGENTS/skills and small-scope low-risk non-invasive changes; confirms completeness, consistency, references, paths, command claims, and unresolved risks with explicit VERIFIED/UNVERIFIED/GAP status.
 ---
 
 # verify-change
 
+## Description
+Root-level, reusable **lightweight verification** skill for full-repo/monorepo handoff checks.
+
+Use this skill to verify delivery readiness of:
+- docs
+- config
+- rules/instructions
+- templates
+- AGENTS files
+- skills
+- small-scope, low-risk, non-invasive code changes
+
+This is **not** an implementation skill and **not** a deep review skill.
+
 ## Purpose
-Perform lightweight but explicit verification before handoff.
+Produce an evidence-based verification result that is clear, bounded, and handoff-ready.
+
+Core goals:
+1. Check completeness against stated intent.
+2. Check consistency across changed artifacts and referenced sources.
+3. Validate reference/path/command claims.
+4. Separate verified facts from unverified assumptions.
+5. Surface unresolved risks and required follow-up checks.
+
+## When to Use
+Use when you need high-level pre-handoff verification for:
+- documentation updates
+- repository instructions/rules/governance updates
+- AGENTS or skill updates
+- template/config updates
+- small-scope code edits that do not change architecture, contracts, or security posture
+
+## When Not to Use
+Do **not** use this skill as the primary workflow for:
+- high-risk backend patches
+- security-sensitive/auth/payment/secret handling changes
+- large refactors or cross-system rewrites
+- new feature implementation
+- deep correctness/performance/concurrency/security review
+
+Escalate to a deeper review/implementation/testing workflow when risk or scope exceeds lightweight verification.
 
 ## Trigger Conditions
-- Docs/config/rules updates
-- Small non-invasive code changes
+Trigger this skill when any of the following is true:
+1. The request explicitly asks for verification/check/handoff-readiness.
+2. The change set is primarily docs/config/rules/templates/AGENTS/skills.
+3. The change set is small, low-risk, and non-invasive, but still needs explicit verification status.
 
 ## Inputs
-- Changed files
-- Relevant repository rules
+Required inputs:
+1. **Stated requirements / intended change** (what should be true after change).
+2. **Changed files list** (actual touched files).
+3. **Affected scope** (root-level, module-level, cross-module).
+4. **Applicable rules/instructions** (AGENTS.md, repo instructions, task constraints).
+5. **Claims to verify**:
+   - path/file existence claims
+   - section/heading/link/reference claims
+   - command usage/execution claims
+   - template/skill/AGENTS reference claims
+6. **Known limitations** (environment, permissions, unavailable tools).
 
-## Steps
-1. Check changed content against stated requirements.
-2. Validate references, paths, and command claims.
-3. Report verified vs unverified items.
+If inputs are missing:
+- mark missing parts as `REQUIRES CONFIRMATION`
+- continue only with verifiable checks
+- do not invent assumptions as facts
 
-## Outputs
-- Verification checklist with pass/gap status
-- Remaining risks and follow-up checks
+## Verification Scope
+### In Scope (high-level)
+1. **Completeness**: changed content covers stated intent.
+2. **Consistency**: no obvious conflict between changed files and related instructions/references.
+3. **Reference validity**: referenced files/sections/skills/templates exist and are correctly named.
+4. **Path validity**: referenced paths are real and reachable in current repo layout.
+5. **Command-claim validity**:
+   - confirmed only if actually executed successfully in this run
+   - otherwise mark `UNVERIFIED` or `BLOCKED BY ENVIRONMENT`
+6. **Risk surfacing**: unresolved risks and follow-up checks are explicitly listed.
+
+### Out of Scope
+- deep code correctness proof
+- full regression testing
+- architecture redesign
+- refactor planning
+- broad risk modeling across unrelated modules
+
+If a “small” code change shows deeper risk (security, schema, API contract, cross-module impact), mark `OUT OF SCOPE` and recommend deeper review.
+
+## Verification Steps
+1. **Set Objective and Boundary**
+   - Restate intended change and verification goal.
+   - Confirm this request fits lightweight verification.
+   - Flag `OUT OF SCOPE` items immediately.
+
+2. **Map Change Set to Intent**
+   - Inspect changed files.
+   - Compare against stated requirements.
+   - Identify missing required updates, extra unintended edits, or mismatch.
+
+3. **Validate References and Claims**
+   - Verify referenced file paths exist.
+   - Verify referenced headings/sections/anchors if applicable.
+   - Verify AGENTS/skill/template references point to valid targets.
+   - Verify command claims only through executed evidence.
+
+4. **Assign Status Per Item**
+   - Label each check item with one status only:
+     - `VERIFIED`
+     - `GAP / INCONSISTENCY`
+     - `UNVERIFIED`
+     - `BLOCKED BY ENVIRONMENT`
+     - `REQUIRES CONFIRMATION`
+     - `OUT OF SCOPE`
+
+5. **Summarize Risks and Follow-up**
+   - List unresolved risks.
+   - List exact follow-up checks needed.
+   - Provide handoff recommendation based on evidence.
+
+## Status Definitions
+- `VERIFIED`: Confirmed by inspected files/content and/or successfully executed commands.
+- `GAP / INCONSISTENCY`: Evidence shows missing requirement, contradiction, broken reference, or mismatch.
+- `UNVERIFIED`: Not enough evidence collected yet; check not executed or not inspectable with current inputs.
+- `BLOCKED BY ENVIRONMENT`: Could not verify due to environment/tool/access/runtime limitation.
+- `REQUIRES CONFIRMATION`: Missing or ambiguous requirement/intent/scope needs human clarification.
+- `OUT OF SCOPE`: Item requires deeper review/implementation workflow beyond this skill.
+
+## Output Contract
+Always output in this structure:
+
+1. **Summary**
+   - What was verified at high level.
+
+2. **Verification Scope**
+   - In-scope targets checked.
+   - Explicit out-of-scope boundaries.
+
+3. **Verified Items (`VERIFIED`)**
+   - Bullet list with evidence source (file path and/or command).
+
+4. **Gaps / Inconsistencies (`GAP / INCONSISTENCY`)**
+   - What failed and why.
+
+5. **Unverified Items (`UNVERIFIED`)**
+   - What remains unproven.
+
+6. **Environment Limitations (`BLOCKED BY ENVIRONMENT`)**
+   - What was blocked and concrete reason.
+
+7. **Requires Confirmation (`REQUIRES CONFIRMATION`)**
+   - Missing decisions/inputs needed from user or owner.
+
+8. **Follow-up Checks**
+   - Exact next checks/commands/review needed.
+
+9. **Handoff Recommendation**
+   - `Ready with noted limitations` or `Not ready`.
+   - Must align with statuses above.
 
 ## Boundaries
-- Do not invent test results.
-- If environment blocks a check, report limitation explicitly.
+1. Do not implement fixes as part of verification unless explicitly requested.
+2. Do not perform deep review while presenting it as lightweight verification.
+3. Do not infer successful execution without command evidence.
+4. Do not treat style preference as a verification gap unless it violates explicit rules.
+5. Do not give optimistic “ready” conclusions for high-risk changes.
+6. Do not hide uncertainty; label it with required status.
 
-## Verification
-- Ensure every conclusion maps to inspected files or executed commands.
+## Verification (Evidence and Traceability)
+For every conclusion:
+1. Link to concrete evidence (inspected file content, path check, executed command output).
+2. Ensure each claimed command result has execution evidence.
+3. Ensure requirement-to-change mapping is explicit.
+4. Ensure unresolved risks are listed, not omitted.
+5. If evidence is partial, downgrade status (`UNVERIFIED`/`REQUIRES CONFIRMATION`/`BLOCKED BY ENVIRONMENT`).
+
+## Failure / Uncertainty / Environment Limitation Handling
+- Command cannot run -> `BLOCKED BY ENVIRONMENT` with reason.
+- Path exists but target content not fully validated -> `UNVERIFIED`.
+- Reference target exists but semantic correctness unclear -> `UNVERIFIED` + follow-up.
+- Requirement unclear or conflicting -> `REQUIRES CONFIRMATION`.
+- Small code change appears riskier than expected -> `OUT OF SCOPE` + escalate to deeper review.
+
+## What Not to Do
+- Do not fabricate test, build, lint, or runtime outcomes.
+- Do not mark “verified” based only on plausibility.
+- Do not silently skip unresolved items.
+- Do not expand into implementation/refactor/feature delivery work.
+- Do not claim comprehensive correctness/security guarantees.


### PR DESCRIPTION
### Motivation
- 使根目錄的 `verify-change` skill 可直接在 full-repo / monorepo 場景下執行，明確支援 docs/config/rules/templates/AGENTS/skills 與 small-scope non-invasive code changes 的交付前驗證。
- 將原本抽象的「high-level verification」轉為可執行、可追溯的流程，強化輸入契約、驗證步驟、狀態分類與輸出格式，避免被誤用為深度審查或實作工具。
- 明確定義 environment 限制、不確定性處理與升級邊界，確保所有結論都要有證據來源（檔案或執行結果）。

### Description
- 完整重寫並擴充 `.agents/skills/verify-change/SKILL.md`，新增或強化以下章節：Frontmatter `name`/`description`、`Description`、`Purpose`、`When to Use`、`When Not to Use`、`Trigger Conditions`、`Inputs`、`Verification Scope`、`Verification Steps`、`Status Definitions`、`Output Contract`、`Boundaries`、`Verification (Evidence and Traceability)`、`Failure / Uncertainty / Environment Limitation Handling`、`What Not to Do`。
- 新增明確輸入契約，包括 `Stated requirements / intended change`、`Changed files list`、`Affected scope`、`Claims to verify` 與 `Known limitations`，並定義當輸入不足時標記為 `REQUIRES CONFIRMATION` 的行為。
- 定義可用的狀態語彙：`VERIFIED`、`GAP / INCONSISTENCY`、`UNVERIFIED`、`BLOCKED BY ENVIRONMENT`、`REQUIRES CONFIRMATION`、`OUT OF SCOPE`，以及固定的輸出合約（9 個段落，如 Summary、Verified Items、Gaps、Unverified、Environment Limitations、Follow-up、Handoff Recommendation 等）。
- 明確列出哪些項目屬於 in-scope（completeness/consistency/reference/path/command-claim/risk surfacing）與 out-of-scope（deep correctness、full regression testing、architecture redesign 等），並提供升級建議（若小改動顯示出深層風險則標記 `OUT OF SCOPE`）。
- 保留並強化「不可捏造命令/測試結果」及避免 scope creep 的 guardrails。
- 文件變更摘要：修改檔案 ` .agents/skills/verify-change/SKILL.md`（約 +177 insertions, -17 deletions）。

### Testing
- 已執行的檢查與命令（皆成功）：
  - `rg --files -g 'AGENTS.md'` — 確認 repo 中存在 `AGENTS.md` 與 `backend/AGENTS.md`。
  - `cat .agents/skills/verify-change/SKILL.md` — 讀取並檢視新版內容。
  - 寫入並覆蓋檔案（`cat > ... <<'EOF'`）— 已成功更新檔案內容。
  - `git status --short && git diff -- .agents/skills/verify-change/SKILL.md` — 檢視差異。
  - `nl -ba .agents/skills/verify-change/SKILL.md | sed -n '1,260p'` — 檢視已寫入內容與行號。
  - `git add` / `git commit -m "Improve verify-change skill for root-level lightweight verification"` — 提交成功（commit id shown in session）。
  - `git show --stat --oneline HEAD` — 確認變更已提交（列出變更行數）。
  - PR 建立請求已呼叫（PR body prepared by automation）。
- 未執行的驗證（需人工或在有權限環境下執行）：
  - 未執行任何自動化測試套件（例如 `./mvnw test`），因為這次變更僅為文件/skill 指令文字更新，且不影響程式碼或建置設定。
- Remaining risks / follow-up checks:
  - 建議在真實驗證請求上使用新版 skill 以驗證術語與輸出格式是否完全符合團隊流程，並根據實務回饋微調文字或狀態分類。
  - 如遇 backend-specific 變更，仍須遵守 `backend/AGENTS.md` 的優先規則並在必要時升級至更深入的 review 流程。
  - 若需在受限環境執行命令（build/test），應在執行前標註並由擁有相應權限的人員或 CI 代為執行，結果才可標為 `VERIFIED`。

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69d4955abdb48323b0e68478af3bd40b)