### PR TITLE
docs(backend): add skill-aware routing, handoff and escalation rules to backend/AGENTS.md

### DIFF
--- a/backend/AGENTS.md
+++ b/backend/AGENTS.md
@@ -90,7 +90,108 @@ First do the minimum needed discovery:
 3. summarize the impacted files and constraints
 4. only then implement
 
-If the repo later has skills such as `scan-project`, `plan-work`, `review-change`, or `backend-test-verification`, use them instead of repeating the workflow in chat.
+Use backend skills for reusable workflows instead of duplicating multi-step SOP in this file.
+
+---
+
+## Backend Skill Routing Policy
+
+Use this section to decide **which backend skill to call first**.  
+Keep detailed execution steps inside each skill.
+
+### Skill entry conditions
+
+- `scan-project-backend`
+  - Use first when backend module boundaries, command map, or architecture context are unclear.
+  - Typical trigger: unfamiliar repo/module, outdated architecture snapshot, or cross-module task.
+- `create-prd`
+  - Use when requirement intent, acceptance criteria, or scope/non-goals are ambiguous.
+  - Typical trigger: new feature with unclear behavior, unclear API/data/auth expectation.
+- `plan-work`
+  - Use after PRD/bug context is known but execution order, risk checkpoints, and validation sequence are not finalized.
+  - Typical trigger: “plan before coding”, “define sequence/risk/validation”.
+- `implement-backend-change`
+  - Use only when scope + acceptance criteria are explicit and implementation is approved.
+  - Typical trigger: concrete backend coding task with bounded targets.
+- `refactor-backend`
+  - Use for refactor-only work where external behavior must remain unchanged.
+  - Typical trigger: technical debt cleanup, deduplication, structure/readability/testability improvement.
+- `review-change`
+  - Use when a patch/diff is ready for correctness/security/maintainability/testing-risk assessment.
+  - Typical trigger: pre-merge review, severity-based findings request, delivery gate decision.
+- `backend-test-verification`
+  - Use when verification evidence is needed for PR/CI/merge readiness.
+  - Typical trigger: run/summarize Maven checks, classify blocking vs non-blocking verification results.
+
+### Routing guardrails
+
+1. If requirement is unclear, do **not** start implementation skill first; route to `create-prd`.
+2. If module context is unclear, do **not** force planning/implementation; route to `scan-project-backend`.
+3. For tiny, obvious, localized bug fixes, direct implementation can be acceptable, but still follow escalation and validation rules.
+4. For medium/high-risk tasks, include both `review-change` and `backend-test-verification` before delivery recommendation.
+
+---
+
+## Recommended Default Sequences
+
+These are default paths, not rigid SOP. Keep detailed sub-steps in skills.
+
+1. **New feature + ambiguous requirement**
+   - `scan-project-backend` (if context unclear) → `create-prd` → `plan-work` → `implement-backend-change` → `review-change` → `backend-test-verification`
+2. **New feature + clear PRD**
+   - `scan-project-backend` (only if module context unclear) → `plan-work` → `implement-backend-change` → `review-change` → `backend-test-verification`
+3. **Bug fix in familiar module**
+   - `plan-work` (lightweight) → `implement-backend-change` → `backend-test-verification`
+4. **Bug fix in unfamiliar module**
+   - `scan-project-backend` → `plan-work` → `implement-backend-change` → `review-change` → `backend-test-verification`
+5. **Refactor-only work**
+   - `scan-project-backend` (if context unclear) → `plan-work` → `refactor-backend` → `review-change` → `backend-test-verification`
+6. **High-risk change (rollback/escalation likely)**
+   - `scan-project-backend` → `create-prd` (if requirement/impact ambiguity exists) → `plan-work` (must include escalation checkpoints) → `implement-backend-change` or `refactor-backend` → `review-change` → `backend-test-verification`
+   - If any checkpoint triggers risk gates in this file, stop and mark `REQUIRES CONFIRMATION` before continuing.
+
+---
+
+## Skill Handoff Contract
+
+When handing off from one skill to another, preserve these minimum outputs.
+
+- `scan-project-backend` → next skill
+  - module map
+  - command map
+  - architecture snapshot
+  - unknowns marked `REQUIRES CONFIRMATION`
+- `create-prd` → next skill
+  - problem statement
+  - scope / non-goals
+  - acceptance criteria
+  - risks / dependencies / open questions
+  - explicit `REQUIRES CONFIRMATION` items
+- `plan-work` → next skill
+  - task type and risk level
+  - ordered execution sequence
+  - validation plan (commands + pass criteria)
+  - escalation checkpoints
+- `implement-backend-change` → next skill
+  - changed files
+  - impact summary (contract unchanged/changed)
+  - commands run + outcomes
+  - remaining risks / unverified areas
+- `refactor-backend` → next skill
+  - preserved invariants checklist
+  - files changed by slice
+  - validation summary
+  - remaining risks / `BLOCKED` / `RISKY` items
+- `review-change` → next skill / final handoff
+  - findings with severity
+  - evidence locations
+  - delivery recommendation
+  - known unknowns / missing evidence
+- `backend-test-verification` → final handoff
+  - verified commands
+  - pass/fail/warn/flaky/skipped/missing-evidence classification
+  - merge recommendation from verification perspective
+  - missing evidence and follow-ups
 
 ### During implementation
 
@@ -377,6 +478,17 @@ Stop and ask for confirmation before making any of these changes:
 7. mail, external API, or background job behavior changes
 8. deleting or moving critical configuration files
 9. changing Spring Boot parent version or core framework setup
+
+### Escalation routing rules
+
+- If risk is discovered during requirement shaping, return to `create-prd` and add `REQUIRES CONFIRMATION`.
+- If risk is discovered during planning, `plan-work` must add an explicit checkpoint and pause before implementation.
+- If risk is discovered during implementation/refactor:
+  1. stop further edits that depend on the risky decision,
+  2. document impacted files/contracts,
+  3. mark `REQUIRES CONFIRMATION`,
+  4. continue only after confirmation.
+- If review/verification finds blocking evidence, recommendation must be non-ship/block-merge until resolved or explicitly accepted.
 
 Small internal refactors or bug fixes may proceed without confirmation only when:
 

--- a/backend/docs/backend-agents-update-log.md
+++ b/backend/docs/backend-agents-update-log.md
@@ -1,0 +1,62 @@
+# Backend AGENTS Update Log
+
+## 2026-04-07 — Skill-aware governance optimization for `backend/AGENTS.md`
+
+### Update goal
+Optimize backend governance so `backend/AGENTS.md` stays durable-rule focused while adding clear, executable routing/handoff/escalation guidance aligned with existing backend skills.
+
+### Files changed
+- `backend/AGENTS.md`
+- `backend/docs/backend-agents-update-log.md` (new)
+
+### Why this update was needed
+- Existing backend governance already had strong durable rules (source-of-truth, validation honesty, layering, risk escalation), but lacked explicit routing policy for backend skills.
+- Skill ordering and cross-skill handoff expectations were implicit, which could lead to inconsistent execution between requirement shaping, planning, implementation, review, and verification.
+- Escalation checkpoints existed as risk categories, but lacked explicit routing guidance when risks are discovered mid-workflow.
+
+### New capabilities added to backend AGENTS
+1. **Backend Skill Routing Policy**
+   - Defines when to start with each backend skill:
+     - `scan-project-backend`
+     - `create-prd`
+     - `plan-work`
+     - `implement-backend-change`
+     - `refactor-backend`
+     - `review-change`
+     - `backend-test-verification`
+   - Adds routing guardrails to prevent premature implementation when context/requirements are unclear.
+
+2. **Recommended Default Sequences**
+   - Adds default (non-SOP) sequences for:
+     - new feature with ambiguous requirements
+     - new feature with clear PRD
+     - bug fix in familiar module
+     - bug fix in unfamiliar module
+     - refactor-only work
+     - high-risk change with rollback/escalation likelihood
+
+3. **Skill Handoff Contract**
+   - Defines minimum artifacts to hand off between skills (module map, PRD outputs, plan outputs, changed files, invariants, findings, verification classifications).
+   - Makes skill-to-skill transitions auditable and reusable.
+
+4. **Escalation Routing Clarification**
+   - Adds routing actions for risk discovered during:
+     - requirement shaping
+     - planning
+     - implementation/refactor
+     - review/verification
+   - Standardizes `REQUIRES CONFIRMATION` pause behavior.
+
+### Deliberately kept out of AGENTS (left in skills)
+To preserve AGENTS/skills boundaries, the following were intentionally **not** moved into `backend/AGENTS.md`:
+- detailed multi-step execution procedures per skill
+- full output templates/rubrics for review or verification
+- command-by-command scan/report mechanics
+- deep PRD drafting format details
+
+These remain in skill definitions under `backend/.agents/skills/`.
+
+### Compatibility and scope notes
+- No backend skill core purpose was changed.
+- No production code, dependency, schema, API, or security flow changes were made.
+- Update is governance/documentation only and scoped to backend workflow consistency.


### PR DESCRIPTION
### Motivation

- 補足現有 `backend/AGENTS.md` 中缺少的 skill-aware 路由、建議序列與交接契約，使 agent 於 backend 工作時能一致選擇與串接現有 skills。 
- 保留原有 durable governance（source-of-truth、layering、validation honesty、risk escalation），而不把多步驟 SOP/範本搬回 AGENTS。 
- 明確當在各階段（需求/規劃/實作/審查）發現風險時應如何 routing 與暫停（`REQUIRES CONFIRMATION`）。

### Description

- 新增 `Backend Skill Routing Policy`，列出何時應先呼叫各 backend skill（含 `scan-project-backend`、`create-prd`、`plan-work`、`implement-backend-change`、`refactor-backend`、`review-change`、`backend-test-verification`）。
- 新增 `Recommended Default Sequences`，提供六類常見情境的預設最短 skill 序列（新功能/bug/refactor/high-risk 等）。
- 新增 `Skill Handoff Contract`，為 skills 之間定義最小交接輸出（例如 `scan`→`module map`、`create-prd`→`acceptance criteria`、`implement`→`changed files`、`backend-test-verification`→`verified commands` 等）。
- 在 `Risk Escalation` 區段補上 `Escalation routing rules`，說明於需求/規劃/實作/審查階段發現風險時的 pause 與回退路由原則（以 `REQUIRES CONFIRMATION` 為停機點）。
- 明確保留邊界：AGENTS 仍只放 durable rules、routing、handoff、escalation；多步驟細節與 rubrics 仍保留在各 skill 的 `SKILL.md` 中。
- 檔案變更：更新 `backend/AGENTS.md`（新增上列章節）並新增說明變更目的的記錄檔 `backend/docs/backend-agents-update-log.md`。

Files changed:
- `backend/AGENTS.md` (更新：新增 routing / sequences / handoff / escalation rules)
- `backend/docs/backend-agents-update-log.md` (新增：變更記錄與理由)

### Testing

- 這次為文件/治理更新，未變更程式碼或相依性，因此未執行 Maven build/tests；若需要，可在後續步驟由 `backend-test-verification` skill 執行具體驗證。 
- 已執行的檢查（檔案與內容驗證，皆成功）： `cat backend/AGENTS.md`, `cat backend/.agents/skills/*/SKILL.md`, `cat backend/docs/backend-project-architecture.md`, `rg --files` 檢索相關檔案，以及局部 `sed`/`nl` 命令以確認新段落正確插入並與現有 skills 名稱一致。 
- 結果：文檔內容已更新並與現有 `backend/.agents/skills/` 定義對齊，無程式碼影響或 build 風險。 
- Remaining risk / follow-ups: 若希望對 routing 規則做更嚴格的一致性稽核，可執行 `verify-change` 類的檢查或請維運/團隊代表確認 escalation 接收者與實際流程；此為可選後續步驟。

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69d4e634937c83239b9e10ab2d9205fb)