### PR TITLE
backend: introduce role aliases, standardize skill names, and add review→verification handoff

### DIFF
--- a/backend/.agents/skills/plan-work/SKILL.md
+++ b/backend/.agents/skills/plan-work/SKILL.md
@@ -32,7 +32,7 @@ Use when all conditions are true:
 ## When Not to Use
 Do not use when any condition is true:
 1. Requirement discovery is still open (use `create-prd` first).
-2. Repository/module context is unknown (use `scan-project` first).
+2. Repository/module context is unknown (use `scan-project-backend` first).
 3. Task is trivial and isolated (single-file tiny fix with obvious validation).
 4. Primary request is implementation, refactor execution, or code review output.
 5. Task is non-backend planning.
@@ -55,7 +55,7 @@ Recommended inputs (must request/flag if missing):
 2. Known risks and open questions.
 3. Test/CI context (available suites, command constraints, runtime limitations).
 4. Architecture assumptions already approved.
-5. Dependencies on other docs/skills (e.g., `scan-project`, `verify-change`).
+5. Dependencies on other docs/skills (e.g., `scan-project-backend`, `verify-change`).
 
 If required input is missing:
 - Stop sequence expansion.
@@ -153,7 +153,7 @@ Follow steps in order. Keep output minimal and executable.
 ## Sequence Design Rules
 Design sequence as shortest valid path, not idealized full lifecycle.
 
-1. Use `scan-project` only when module/flow evidence is insufficient.
+1. Use `scan-project-backend` only when module/flow evidence is insufficient.
 2. Use `create-prd` only when requirement intent/acceptance is incomplete.
 3. Schedule implementation step only after scope/risk/validation are defined.
 4. Add `review`/`verify` steps when risk is `Medium`/`High` or change is cross-layer.

--- a/backend/.agents/skills/review-change/SKILL.md
+++ b/backend/.agents/skills/review-change/SKILL.md
@@ -182,6 +182,11 @@ Always return in this stable structure:
    - List missing requirements, missing tests/CI, ambiguous intent, or out-of-scope risks.
    - State exactly what evidence is needed to close each gap.
 
+5. **Verification Focus Handoff (for `backend-test-verification`)**
+   - Must-run verification focus list tied to highest-risk findings.
+   - Include command/check suggestions for each focus (targeted first, then broader if needed).
+   - Mark each focus as `Blocking` or `Non-blocking` from review perspective.
+
 ## Boundaries
 - Every finding must be evidence-based and traceable to changed code.
 - Do not present speculation as confirmed defect.
@@ -203,6 +208,11 @@ Use these exact labels when evidence is incomplete:
 - `REQUIRES CONFIRMATION`: requirement/intent is unclear; cannot assert correctness conclusively.
 - `INSUFFICIENT EVIDENCE`: missing required artifacts (tests/CI/logs/design context).
 - `RISK NOT VERIFIED`: risk suspected but cannot be validated from available diff/context.
+
+If any potential `P0`/`P1` risk lacks sufficient evidence for a final ship recommendation:
+- mark `REQUIRES CONFIRMATION`,
+- emit explicit verification focus items for `backend-test-verification`,
+- recommend `FIX REQUIRED BEFORE SHIP` until verification evidence closes the gap.
 
 When any label appears:
 - State what is unknown.

--- a/backend/AGENTS.md
+++ b/backend/AGENTS.md
@@ -99,27 +99,47 @@ Use backend skills for reusable workflows instead of duplicating multi-step SOP 
 Use this section to decide **which backend skill to call first**.  
 Keep detailed execution steps inside each skill.
 
+### Backend Service Taxonomy (Formal Governance)
+
+Use human-facing role aliases in workflow communication, and keep technical skill names as execution identifiers.
+
+- `PDM` (`create-prd`): requirement definition and acceptance criteria.
+- `PJM-Discovery` (`scan-project-backend`): backend context discovery and architecture snapshot.
+- `PJM-Execution` (`plan-work`): execution sequencing, risk, and validation planning.
+- `DEV` (`implement-backend-change`): approved scoped backend implementation.
+- `DEV-Refactor` (`refactor-backend`): refactor-only execution with behavior preservation.
+- `DEV-Review` (`review-change`): risk-oriented code review and delivery recommendation.
+- `QA` (`backend-test-verification`): verification evidence and merge-readiness recommendation.
+
+Governance rules:
+1. Human-facing workflow docs should prefer alias-first notation such as `PDM (create-prd)`.
+2. Skill routing and technical invocation must preserve technical skill names as source of truth.
+3. `DEV-Review` and `QA` are dual-track quality gates:
+   - `DEV-Review` focuses on risk judgement and severity assessment.
+   - `QA` focuses on executable verification evidence and merge recommendation.
+4. If alias wording and technical skill naming conflict, technical skill naming wins.
+
 ### Skill entry conditions
 
-- `scan-project-backend`
+- `PJM-Discovery` (`scan-project-backend`)
   - Use first when backend module boundaries, command map, or architecture context are unclear.
   - Typical trigger: unfamiliar repo/module, outdated architecture snapshot, or cross-module task.
-- `create-prd`
+- `PDM` (`create-prd`)
   - Use when requirement intent, acceptance criteria, or scope/non-goals are ambiguous.
   - Typical trigger: new feature with unclear behavior, unclear API/data/auth expectation.
-- `plan-work`
+- `PJM-Execution` (`plan-work`)
   - Use after PRD/bug context is known but execution order, risk checkpoints, and validation sequence are not finalized.
   - Typical trigger: “plan before coding”, “define sequence/risk/validation”.
-- `implement-backend-change`
+- `DEV` (`implement-backend-change`)
   - Use only when scope + acceptance criteria are explicit and implementation is approved.
   - Typical trigger: concrete backend coding task with bounded targets.
-- `refactor-backend`
+- `DEV-Refactor` (`refactor-backend`)
   - Use for refactor-only work where external behavior must remain unchanged.
   - Typical trigger: technical debt cleanup, deduplication, structure/readability/testability improvement.
-- `review-change`
+- `DEV-Review` (`review-change`)
   - Use when a patch/diff is ready for correctness/security/maintainability/testing-risk assessment.
   - Typical trigger: pre-merge review, severity-based findings request, delivery gate decision.
-- `backend-test-verification`
+- `QA` (`backend-test-verification`)
   - Use when verification evidence is needed for PR/CI/merge readiness.
   - Typical trigger: run/summarize Maven checks, classify blocking vs non-blocking verification results.
 
@@ -137,17 +157,17 @@ Keep detailed execution steps inside each skill.
 These are default paths, not rigid SOP. Keep detailed sub-steps in skills.
 
 1. **New feature + ambiguous requirement**
-   - `scan-project-backend` (if context unclear) → `create-prd` → `plan-work` → `implement-backend-change` → `review-change` → `backend-test-verification`
+   - `PJM-Discovery (scan-project-backend)` (if context unclear) → `PDM (create-prd)` → `PJM-Execution (plan-work)` → `DEV (implement-backend-change)` → `DEV-Review (review-change)` → `QA (backend-test-verification)`
 2. **New feature + clear PRD**
-   - `scan-project-backend` (only if module context unclear) → `plan-work` → `implement-backend-change` → `review-change` → `backend-test-verification`
+   - `PJM-Discovery (scan-project-backend)` (only if module context unclear) → `PJM-Execution (plan-work)` → `DEV (implement-backend-change)` → `DEV-Review (review-change)` → `QA (backend-test-verification)`
 3. **Bug fix in familiar module**
-   - `plan-work` (lightweight) → `implement-backend-change` → `backend-test-verification`
+   - `PJM-Execution (plan-work)` (lightweight) → `DEV (implement-backend-change)` → `QA (backend-test-verification)`
 4. **Bug fix in unfamiliar module**
-   - `scan-project-backend` → `plan-work` → `implement-backend-change` → `review-change` → `backend-test-verification`
+   - `PJM-Discovery (scan-project-backend)` → `PJM-Execution (plan-work)` → `DEV (implement-backend-change)` → `DEV-Review (review-change)` → `QA (backend-test-verification)`
 5. **Refactor-only work**
-   - `scan-project-backend` (if context unclear) → `plan-work` → `refactor-backend` → `review-change` → `backend-test-verification`
+   - `PJM-Discovery (scan-project-backend)` (if context unclear) → `PJM-Execution (plan-work)` → `DEV-Refactor (refactor-backend)` → `DEV-Review (review-change)` → `QA (backend-test-verification)`
 6. **High-risk change (rollback/escalation likely)**
-   - `scan-project-backend` → `create-prd` (if requirement/impact ambiguity exists) → `plan-work` (must include escalation checkpoints) → `implement-backend-change` or `refactor-backend` → `review-change` → `backend-test-verification`
+   - `PJM-Discovery (scan-project-backend)` → `PDM (create-prd)` (if requirement/impact ambiguity exists) → `PJM-Execution (plan-work)` (must include escalation checkpoints) → `DEV (implement-backend-change)` or `DEV-Refactor (refactor-backend)` → `DEV-Review (review-change)` → `QA (backend-test-verification)`
    - If any checkpoint triggers risk gates in this file, stop and mark `REQUIRES CONFIRMATION` before continuing.
 
 ---
@@ -187,6 +207,7 @@ When handing off from one skill to another, preserve these minimum outputs.
   - evidence locations
   - delivery recommendation
   - known unknowns / missing evidence
+  - verification focus list for `backend-test-verification` (blocking vs non-blocking)
 - `backend-test-verification` → final handoff
   - verified commands
   - pass/fail/warn/flaky/skipped/missing-evidence classification

--- a/backend/docs/prd/backend-agents-skills-alignment-improvement-prd.md
+++ b/backend/docs/prd/backend-agents-skills-alignment-improvement-prd.md
@@ -1,0 +1,104 @@
+# Backend AGENTS × Skills Alignment Improvement PRD
+
+## Summary
+This PRD defines a governance-focused improvement package for backend agent orchestration.  
+Goal: keep existing backend technical skill identifiers unchanged while formally introducing human-facing role taxonomy (`PDM/PJM/DEV/QA`) into routing, handoff, and workflow communication.
+
+## Problem Statement
+Current backend governance and skills are mostly aligned, but operational readability and cross-skill handoff clarity can still improve:
+
+1. Human-facing role naming is not formalized in backend governance.
+2. Some skill wording uses inconsistent technical naming (`scan-project` vs `scan-project-backend`).
+3. Review and verification workflows are complementary but need clearer handoff focus.
+
+## Desired Outcomes
+1. Backend governance includes a formal alias taxonomy:
+   - `PDM`, `PJM-Discovery`, `PJM-Execution`, `DEV`, `DEV-Refactor`, `DEV-Review`, `QA`.
+2. Routing and recommended sequences adopt alias-first display with technical name in parentheses.
+3. `review-change` explicitly outputs verification focus for `backend-test-verification`.
+4. Technical skill names remain authoritative execution identifiers.
+
+## Scope (In Scope)
+1. Update `backend/AGENTS.md`:
+   - add formal backend service taxonomy section;
+   - update routing/sequence wording to alias-first format;
+   - add review → verification handoff field.
+2. Update backend skills where wording consistency is required:
+   - normalize `scan-project-backend` naming in `plan-work`.
+   - add explicit verification-focus handoff requirement in `review-change`.
+
+## Non-Goals (Out of Scope)
+1. Renaming physical skill directories or technical identifiers.
+2. Changing backend application code behavior.
+3. Merging `review-change` and `backend-test-verification` into one skill.
+4. Introducing new dependencies, schema/auth flow changes, or architecture redesign.
+
+## Affected Boundaries
+1. Governance docs:
+   - `backend/AGENTS.md`
+2. Backend skill docs:
+   - `backend/.agents/skills/plan-work/SKILL.md`
+   - `backend/.agents/skills/review-change/SKILL.md`
+3. PRD documentation:
+   - this file
+
+## User Scenarios
+1. As a maintainer, I can read backend workflow using role labels (`PDM/PJM/DEV/QA`) without losing technical precision.
+2. As an operator, I can route tasks consistently because role aliases map to exact technical skills.
+3. As a reviewer/QA collaborator, I can hand off risk-based verification focus without ambiguity.
+
+## Governance Behavior Definition
+1. Alias-first communication format:
+   - `<Role Alias> (<Technical Skill Name>)`
+2. Routing source of truth:
+   - Technical skill names remain canonical for invocation.
+3. Quality dual-track:
+   - `DEV-Review (review-change)` handles risk judgement.
+   - `QA (backend-test-verification)` handles executable evidence and merge readiness.
+
+## Validation / Escalation Impact
+### Confirmed
+1. Validation honesty policy remains unchanged.
+2. Existing escalation gates remain in force.
+
+### Potential
+1. Alias misuse risk if documentation omits technical names.
+
+### Mitigation
+1. Keep alias-first + technical-name format in governance text.
+2. Keep explicit rule: technical names win on conflict.
+
+## Acceptance Criteria
+- **AC-001**  
+  **Given** backend governance docs are read by human operators  
+  **When** they inspect routing and default sequences  
+  **Then** each step is shown as role alias + technical skill name.
+
+- **AC-002**  
+  **Given** planning skill references scan skill  
+  **When** `plan-work` is read  
+  **Then** it references `scan-project-backend` consistently.
+
+- **AC-003**  
+  **Given** review output is handed to QA verification  
+  **When** `review-change` output contract is applied  
+  **Then** it includes explicit verification focus items with blocking/non-blocking labeling.
+
+- **AC-004**  
+  **Given** governance and skill naming are both present  
+  **When** naming conflict is encountered  
+  **Then** technical skill names are explicitly defined as source of truth.
+
+## Risks
+1. Over-abstract role naming could hide technical routing precision.
+2. Partial adoption may create mixed terminology temporarily.
+
+## Dependencies
+1. Backend maintainers follow alias-first communication in future docs.
+2. Future skill additions include alias mapping updates.
+
+## Open Questions
+1. Should future dashboards/automation expose alias names by default while storing technical names internally?
+
+## Requires Confirmation
+1. If future governance requires machine-readable service taxonomy (JSON/YAML), confirm target format and owning document before implementation.


### PR DESCRIPTION
### Motivation
- Improve backend governance readability by introducing human-facing role aliases while preserving technical skill identifiers as the source of truth.
- Standardize references to the backend scan skill (`scan-project-backend`) across planning materials to avoid ambiguous naming.
- Make review→verification handoffs explicit so `review-change` outputs verification focus items usable by `backend-test-verification` for merge decisions.

### Description
- Add a formal Backend Service Taxonomy and alias-first routing guidance to `backend/AGENTS.md`, and update recommended sequences to show role aliases with technical skill names in parentheses. 
- Normalize skill references in `backend/.agents/skills/plan-work/SKILL.md` to use `scan-project-backend` and update dependency mentions accordingly. 
- Extend `backend/.agents/skills/review-change/SKILL.md` with a `Verification Focus Handoff` section and a requirement to mark `P0`/`P1` gaps as `REQUIRES CONFIRMATION` while emitting verification focus items and recommending `FIX REQUIRED BEFORE SHIP` when evidence is insufficient. 
- Add a governance PRD `backend/docs/prd/backend-agents-skills-alignment-improvement-prd.md` documenting goals, scope, acceptance criteria, and rationale for these changes.

### Testing
- These are documentation-only changes, so no automated unit or integration tests were run. 
- No automated docs build or linting was executed as part of this change set.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d5e75a39a083239c656524ae759e84)