### PR TITLE
docs(backend-skills): alias-first wording and review→QA verification linkage

### DIFF
--- a/backend/.agents/skills/plan-work/SKILL.md
+++ b/backend/.agents/skills/plan-work/SKILL.md
@@ -153,6 +153,11 @@ Follow steps in order. Keep output minimal and executable.
 ## Sequence Design Rules
 Design sequence as shortest valid path, not idealized full lifecycle.
 
+Use alias-first wording when describing workflow actors in plan output:
+- Format: `<Role Alias> (<Technical Skill Name>)`
+- Example: `PJM-Discovery (scan-project-backend)`
+- If alias wording and technical skill name conflict, technical skill name is authoritative.
+
 1. Use `scan-project-backend` only when module/flow evidence is insufficient.
 2. Use `create-prd` only when requirement intent/acceptance is incomplete.
 3. Schedule implementation step only after scope/risk/validation are defined.

--- a/backend/.agents/skills/review-change/SKILL.md
+++ b/backend/.agents/skills/review-change/SKILL.md
@@ -184,6 +184,7 @@ Always return in this stable structure:
 
 5. **Verification Focus Handoff (for `backend-test-verification`)**
    - Must-run verification focus list tied to highest-risk findings.
+   - Each focus item must reference related finding `ID`(s).
    - Include command/check suggestions for each focus (targeted first, then broader if needed).
    - Mark each focus as `Blocking` or `Non-blocking` from review perspective.
 

--- a/backend/AGENTS.md
+++ b/backend/AGENTS.md
@@ -207,7 +207,7 @@ When handing off from one skill to another, preserve these minimum outputs.
   - evidence locations
   - delivery recommendation
   - known unknowns / missing evidence
-  - verification focus list for `backend-test-verification` (blocking vs non-blocking)
+  - verification focus list for `backend-test-verification` (blocking vs non-blocking, linked to finding IDs)
 - `backend-test-verification` → final handoff
   - verified commands
   - pass/fail/warn/flaky/skipped/missing-evidence classification


### PR DESCRIPTION
### Motivation
- 依據 `backend-agents-skills-alignment-improvement-prd.md` 的治理目標，讓人類可讀的角色別名（PDM/PJM/DEV/QA）在技能輸出中優先顯示，同時保留技術技能名稱為執行識別依據。 
- 增強 review → QA 的交接可追溯性，要求 `review-change` 的驗證焦點（verification focus）需連結對應 finding ID，讓 `backend-test-verification` 能直接追蹤高風險項目。 

### Description
- 新增 alias-first 撰寫規範於 `plan-work`：在輸出中要求使用格式 `<Role Alias> (<Technical Skill Name>)` 並說明若衝突以技術技能名稱為準，變更檔案為 `backend/.agents/skills/plan-work/SKILL.md`。 
- 在 `review-change` 的輸出契約中加入要求：每個 verification focus 必須參照相關 finding `ID`，變更檔案為 `backend/.agents/skills/review-change/SKILL.md`。 
- 同步更新 `backend/AGENTS.md` 的交接清單，將 review → QA 的驗證焦點說明為「需連結 finding IDs」，變更檔案為 `backend/AGENTS.md`。 

### Testing
- 嘗試執行 `cd backend && ./mvnw -q -DskipTests validate`，但在此環境中 `./mvnw` 權限不足導致失敗（`Permission denied`）。 
- 執行 `cd backend && mvn -q -DskipTests validate` 成功通過，表示基礎驗證步驟可執行（雖非使用 wrapper）。 
- 變更僅限文件/技能規範，未觸及應用程式程式碼、資料庫 schema、認證或相依性，風險低；建議在 CI 或合併前補跑 `./mvnw test` 或 `./mvnw clean install` 以完成完整驗證。

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d5e9fc280c8323891b571f27a5c7f9)